### PR TITLE
feat: Update ADW process to checkout the default branch (#18)

### DIFF
--- a/adws/__tests__/gitOperations.test.ts
+++ b/adws/__tests__/gitOperations.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+vi.mock('../core/utils', () => ({
+  log: vi.fn(),
+}));
+
+import { execSync } from 'child_process';
+import { getDefaultBranch, checkoutDefaultBranch } from '../github/gitOperations';
+
+describe('getDefaultBranch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the default branch name from gh CLI', () => {
+    vi.mocked(execSync).mockReturnValue('main\n');
+
+    const result = getDefaultBranch();
+
+    expect(result).toBe('main');
+    expect(execSync).toHaveBeenCalledWith(
+      "gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'",
+      { encoding: 'utf-8' }
+    );
+  });
+
+  it('trims whitespace from the branch name', () => {
+    vi.mocked(execSync).mockReturnValue('  develop  \n');
+
+    const result = getDefaultBranch();
+
+    expect(result).toBe('develop');
+  });
+
+  it('throws error when gh command fails', () => {
+    vi.mocked(execSync).mockImplementation(() => {
+      throw new Error('gh: command not found');
+    });
+
+    expect(() => getDefaultBranch()).toThrow('Failed to get default branch');
+  });
+
+  it('throws error when gh returns empty string', () => {
+    vi.mocked(execSync).mockReturnValue('');
+
+    expect(() => getDefaultBranch()).toThrow('GitHub CLI returned empty default branch name');
+  });
+
+  it('throws error when gh returns only whitespace', () => {
+    vi.mocked(execSync).mockReturnValue('   \n');
+
+    expect(() => getDefaultBranch()).toThrow('GitHub CLI returned empty default branch name');
+  });
+});
+
+describe('checkoutDefaultBranch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('checks out the default branch and pulls latest changes', () => {
+    vi.mocked(execSync)
+      .mockReturnValueOnce('main\n') // getDefaultBranch call
+      .mockReturnValueOnce('') // git checkout
+      .mockReturnValueOnce(''); // git pull
+
+    const result = checkoutDefaultBranch();
+
+    expect(result).toBe('main');
+    expect(execSync).toHaveBeenCalledTimes(3);
+    expect(execSync).toHaveBeenNthCalledWith(
+      1,
+      "gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'",
+      { encoding: 'utf-8' }
+    );
+    expect(execSync).toHaveBeenNthCalledWith(
+      2,
+      'git checkout main',
+      { stdio: 'pipe' }
+    );
+    expect(execSync).toHaveBeenNthCalledWith(
+      3,
+      'git pull origin main',
+      { stdio: 'pipe' }
+    );
+  });
+
+  it('works with different default branch names', () => {
+    vi.mocked(execSync)
+      .mockReturnValueOnce('develop\n') // getDefaultBranch call
+      .mockReturnValueOnce('') // git checkout
+      .mockReturnValueOnce(''); // git pull
+
+    const result = checkoutDefaultBranch();
+
+    expect(result).toBe('develop');
+    expect(execSync).toHaveBeenNthCalledWith(
+      2,
+      'git checkout develop',
+      { stdio: 'pipe' }
+    );
+    expect(execSync).toHaveBeenNthCalledWith(
+      3,
+      'git pull origin develop',
+      { stdio: 'pipe' }
+    );
+  });
+
+  it('throws error when checkout fails', () => {
+    vi.mocked(execSync)
+      .mockReturnValueOnce('main\n') // getDefaultBranch call
+      .mockImplementationOnce(() => {
+        throw new Error('error: Your local changes would be overwritten');
+      });
+
+    expect(() => checkoutDefaultBranch()).toThrow("Failed to checkout default branch 'main'");
+  });
+
+  it('throws error when pull fails', () => {
+    vi.mocked(execSync)
+      .mockReturnValueOnce('main\n') // getDefaultBranch call
+      .mockReturnValueOnce('') // git checkout succeeds
+      .mockImplementationOnce(() => {
+        throw new Error('fatal: unable to access remote');
+      });
+
+    expect(() => checkoutDefaultBranch()).toThrow("Failed to pull latest changes for 'main'");
+  });
+
+  it('throws error when getting default branch fails', () => {
+    vi.mocked(execSync).mockImplementation(() => {
+      throw new Error('gh: not logged in');
+    });
+
+    expect(() => checkoutDefaultBranch()).toThrow('Failed to get default branch');
+  });
+});

--- a/adws/adwPlanBuild.tsx
+++ b/adws/adwPlanBuild.tsx
@@ -38,6 +38,7 @@ import {
   WorkflowContext,
   detectRecoveryState,
   STAGE_ORDER,
+  checkoutDefaultBranch,
 } from './github';
 import {
   runPlanAgent,
@@ -227,6 +228,10 @@ async function main(): Promise<void> {
   log('Fetching GitHub issue...', 'info');
   const issue = await fetchGitHubIssue(issueNumber);
   log(`Fetched issue: ${issue.title}`, 'success');
+
+  // Step 1.5: Checkout default branch and pull latest changes
+  // This ensures feature branches are created from the latest code
+  const defaultBranch = checkoutDefaultBranch();
 
   // Detect recovery state from existing comments
   const recoveryState = detectRecoveryState(issue.comments);

--- a/adws/github/gitOperations.ts
+++ b/adws/github/gitOperations.ts
@@ -89,3 +89,54 @@ export function pushBranch(branchName: string): void {
   execSync(`git push -u origin ${branchName}`, { stdio: 'pipe' });
   log(`Pushed branch to origin`, 'success');
 }
+
+/**
+ * Gets the default branch name of the repository using the GitHub CLI.
+ * @returns The name of the default branch (e.g., 'main', 'master', 'develop')
+ */
+export function getDefaultBranch(): string {
+  try {
+    const result = execSync(
+      "gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'",
+      { encoding: 'utf-8' }
+    );
+    const branchName = result.trim();
+
+    if (!branchName) {
+      throw new Error('GitHub CLI returned empty default branch name');
+    }
+
+    return branchName;
+  } catch (error) {
+    throw new Error(`Failed to get default branch: ${error}`);
+  }
+}
+
+/**
+ * Checks out the repository's default branch and pulls the latest changes.
+ * This ensures the working directory is on the latest version of the default branch
+ * before creating feature branches.
+ * @returns The name of the default branch that was checked out.
+ */
+export function checkoutDefaultBranch(): string {
+  log('Checking out default branch...', 'info');
+
+  const defaultBranch = getDefaultBranch();
+  log(`Default branch is: ${defaultBranch}`, 'info');
+
+  try {
+    execSync(`git checkout ${defaultBranch}`, { stdio: 'pipe' });
+    log(`Checked out branch: ${defaultBranch}`, 'success');
+  } catch (error) {
+    throw new Error(`Failed to checkout default branch '${defaultBranch}': ${error}`);
+  }
+
+  try {
+    execSync(`git pull origin ${defaultBranch}`, { stdio: 'pipe' });
+    log(`Pulled latest changes from origin/${defaultBranch}`, 'success');
+  } catch (error) {
+    throw new Error(`Failed to pull latest changes for '${defaultBranch}': ${error}`);
+  }
+
+  return defaultBranch;
+}

--- a/adws/github/index.ts
+++ b/adws/github/index.ts
@@ -23,6 +23,8 @@ export {
   checkoutBranch,
   commitChanges,
   pushBranch,
+  getDefaultBranch,
+  checkoutDefaultBranch,
 } from './gitOperations';
 
 // Pull Request Creator

--- a/specs/issue-18-plan.md
+++ b/specs/issue-18-plan.md
@@ -1,0 +1,127 @@
+# Chore: Update ADW Process to Checkout the Default Branch
+
+## Chore Description
+Before the ADW (AI Developer Workflow) process starts, the local branch must be set to the default branch. This ensures that feature branches are created from the latest version of the default branch, preventing conflicts and ensuring a clean starting point for each workflow run.
+
+The implementation requires:
+1. Finding out what the current default branch is (could be `main`, `master`, `develop`, etc.)
+2. Checking out the default branch locally
+3. Pulling in the latest changes from remote
+
+## User Story
+As a **developer using the ADW workflow**
+I want the **ADW process to automatically checkout the default branch before starting**
+So that **feature branches are always created from the latest code, reducing merge conflicts and ensuring consistency**
+
+## Problem Statement
+Currently, the ADW workflow (`adwPlanBuild.tsx`) does not verify or reset the working branch before creating a feature branch. If a developer runs the ADW process while on an old or unrelated branch, the feature branch will be created from that state, potentially causing issues like:
+- Creating branches from outdated code
+- Inheriting unwanted changes from a different feature branch
+- Merge conflicts when creating the PR
+
+## Solution Statement
+Add a new step at the beginning of the ADW Plan & Build workflow that:
+1. Queries the GitHub API to determine the repository's default branch name
+2. Checks out the default branch
+3. Pulls the latest changes from the remote to ensure the local copy is up to date
+
+This will be implemented as reusable functions in `gitOperations.ts` that can be used by both `adwPlanBuild.tsx` and potentially other workflows.
+
+## Relevant Files
+Use these files to resolve the chore:
+
+### Existing Files (to modify)
+- `adws/github/gitOperations.ts` — Add new functions `getDefaultBranch()` and `checkoutDefaultBranch()` for default branch operations
+- `adws/github/index.ts` — Export the new functions from the github module
+- `adws/adwPlanBuild.tsx` — Call `checkoutDefaultBranch()` at the start of the workflow before any other operations
+- `adws/index.ts` — Export the new functions from the main adws module (if needed for external use)
+
+### New Files
+- `adws/__tests__/gitOperations.test.ts` — Unit tests for the new git operations functions
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### Step 1: Add `getDefaultBranch()` Function to gitOperations.ts
+- Open `adws/github/gitOperations.ts`
+- Add a new function `getDefaultBranch()` that:
+  - Uses the `gh` CLI to query the repository's default branch: `gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'`
+  - Returns the default branch name as a string (e.g., `main`, `master`, `develop`)
+  - Handles errors appropriately with meaningful error messages
+  - Uses the existing `log` utility for consistent logging
+
+### Step 2: Add `checkoutDefaultBranch()` Function to gitOperations.ts
+- In `adws/github/gitOperations.ts`, add a new function `checkoutDefaultBranch()` that:
+  - Calls `getDefaultBranch()` to get the default branch name
+  - Executes `git checkout <default-branch>` to switch to the default branch
+  - Executes `git pull origin <default-branch>` to pull the latest changes
+  - Uses the existing `log` utility to report success/progress
+  - Handles errors appropriately (e.g., uncommitted changes, network issues)
+  - Returns the default branch name for reference
+
+### Step 3: Export New Functions from github/index.ts
+- Open `adws/github/index.ts`
+- Add exports for `getDefaultBranch` and `checkoutDefaultBranch` from `./gitOperations`
+
+### Step 4: Update adwPlanBuild.tsx to Use checkoutDefaultBranch()
+- Open `adws/adwPlanBuild.tsx`
+- Import `checkoutDefaultBranch` from `./github`
+- In the `main()` function, add a call to `checkoutDefaultBranch()` immediately after fetching the GitHub issue (before recovery state detection)
+- Add appropriate logging to indicate this step is being executed
+- Store the returned default branch name for potential later use (e.g., PR base branch)
+
+### Step 5: Create Unit Tests for New Functions
+- Create `adws/__tests__/gitOperations.test.ts`
+- Add tests for `getDefaultBranch()`:
+  - Test successful retrieval of default branch name
+  - Test error handling when `gh` command fails
+- Add tests for `checkoutDefaultBranch()`:
+  - Test successful checkout and pull
+  - Test handling of checkout failures
+  - Test handling of pull failures
+- Use the same mocking patterns as `adws/__tests__/githubApi.test.ts` (mock `child_process` and `../core/utils`)
+
+### Step 6: Run Validation Commands
+- Execute all validation commands to verify the implementation works correctly with zero regressions
+
+## Testing Strategy
+
+### Unit Tests
+- Test `getDefaultBranch()` returns the correct branch name from mocked `gh` output
+- Test `getDefaultBranch()` throws appropriate error when `gh` command fails
+- Test `checkoutDefaultBranch()` executes correct git commands in sequence
+- Test `checkoutDefaultBranch()` handles errors gracefully
+
+### Integration Testing
+- Run the ADW workflow on a test issue to verify the default branch checkout occurs
+- Verify that feature branches are created from the default branch
+- Test recovery scenario: ensure the workflow still works when recovering from a previous run
+
+### Manual Testing
+- Start from a non-default branch and run `npx tsx adws/adwPlanBuild.tsx <issue-number>`
+- Verify the workflow checks out the default branch before proceeding
+- Verify the workflow pulls the latest changes
+
+## Acceptance Criteria
+- [ ] `getDefaultBranch()` function exists in `gitOperations.ts` and returns the repository's default branch name
+- [ ] `checkoutDefaultBranch()` function exists in `gitOperations.ts` and checks out + pulls the default branch
+- [ ] The ADW Plan & Build workflow (`adwPlanBuild.tsx`) calls `checkoutDefaultBranch()` at the start before creating feature branches
+- [ ] Unit tests exist and pass for the new functions
+- [ ] `npm run lint` passes with no errors
+- [ ] `npm run build` passes with no errors
+- [ ] `npm test` passes with no regressions
+- [ ] The workflow works correctly when started from any branch
+
+## Validation Commands
+Execute every command to validate the chore is complete with zero regressions.
+
+- `npm run lint` — Run linter to check for code quality issues
+- `npm run build` — Build the application to verify no build errors
+- `npm test` — Run tests to validate the implementation and ensure no regressions
+
+## Notes
+- The `gh` CLI is already used throughout the codebase for GitHub operations, so using it for fetching the default branch is consistent with existing patterns
+- The function should work with any default branch name (main, master, develop, etc.) since different repositories use different conventions
+- Consider whether to skip the checkout if already on the default branch (optimization, but not required for initial implementation)
+- The `checkoutBranch()` function already exists but is used for checking out specific named branches; the new `checkoutDefaultBranch()` function adds the step of dynamically determining which branch to checkout
+- Error handling should be robust since this runs at the start of the workflow — a failure here should stop the workflow early with a clear error message


### PR DESCRIPTION
## Summary
Implements #18 - Update ADW process to checkout the default branch

## Implementation Plan
I've created the implementation plan. Let me provide a summary.

## Summary

Created the implementation plan at `specs/issue-18-plan.md` for GitHub issue #18: "Update ADW process to checkout the default branch".

### What the plan covers:

- **New functions in `gitOperations.ts`:**
  - `getDefaultBranch()` — Uses `gh repo view` to query the repository's default branch name
  - `checkoutDefaultBranch()` — Checks out and pulls the default branch

- **Workflow integration:**
  - Updates `adwPlanBuild.tsx` to call `checkoutDefaultBranch()` at the start of the workflow, before creating feature branches

- **Testing:**
  - Creates new unit tests in `adws/__tests__/gitOperations.test.ts` following the existing test patterns

- **Files to modify:**
  1. `adws/github/gitOperations.ts` — Add new functions
  2. `adws/github/index.ts` — Export new functions
  3. `adws/adwPlanBuild.tsx` — Integrate at workflow start
  4. `adws/__tests__/gitOperations.test.ts` (new) — Unit tests

- **Validation commands:**
  - `npm run lint`
  - `npm run build`
  - `npm test`

The plan ensures feature branches are always created from the latest version of the default branch, preventing conflicts and ensuring consistency across ADW workflow runs.

## Changes Made
## Implementation Summary

### What Was Implemented
The ADW (AI Developer Workflow) process now automatically checks out the default branch before starting. This ensures feature branches are always created from the latest code, reducing merge conflicts and ensuring consistency.

### Files Changed/Created

**Modified Files:**
1. **`adws/github/gitOperations.ts`** — Added two new functions:
   - `getDefaultBranch()`: Uses the `gh` CLI to query the repository's default branch name
   - `checkoutDefaultBranch()`: Checks out the default branch and pulls latest changes from remote

2. **`adws/github/index.ts`** — Added exports for `getDefaultBranch` and `checkoutDefaultBranch`

3. **`adws/adwPlanBuild.tsx`** — Added import and call to `checkoutDefaultBranch()` after fetching the GitHub issue (before recovery state detection)

**New Files:**
1. **`adws/__tests__/gitOperations.test.ts`** — Unit tests for the new functions (10 tests covering success cases and error handling)

### Validation Results
- `npm run lint` — ✅ No ESLint warnings or errors
- `npm run build` — ✅ Compiled successfully
- `npm test` — ✅ 16 tests passed (6 existing + 10 new)

### Acceptance Criteria Met
- ✅ `getDefaultBranch()` function exists and returns the repository's default branch name
- ✅ `checkoutDefaultBranch()` function exists and checks out + pulls the default branch
- ✅ The ADW Plan & Build workflow calls `checkoutDefaultBranch()` at the start before creating feature branches
- ✅ Unit tests exist and pass for the new functions
- ✅ `npm run lint` passes with no errors
- ✅ `npm run build` passes with no errors
- ✅ `npm test` passes with no regressions
- ✅ The workflow will work correctly when started from any branch (the implementation dynamically fetches and uses the repository's default branch)

## Testing
- [ ] All validation commands from the plan pass
- [ ] No regressions introduced
- [ ] Code follows project conventions

---
Generated by ADW Plan & Build workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds mandatory `git checkout`/`git pull` at workflow start, which can fail due to local state (uncommitted changes), auth, or network and will now block the ADW run. Logic is straightforward and covered by unit tests, but it changes the workflow’s side effects on the user’s working directory.
> 
> **Overview**
> ADW Plan & Build now **forces the working directory onto the repo’s default branch and updates it** before any feature-branch creation, ensuring new branches start from the latest default branch.
> 
> This introduces `getDefaultBranch()` (queries `gh repo view ... defaultBranchRef.name`) and `checkoutDefaultBranch()` (checkout + pull with explicit error handling) in `gitOperations`, exports them via `adws/github/index.ts`, and adds Vitest coverage for success and failure scenarios (empty branch name, gh failures, checkout/pull failures).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17009a932981808ac0aab27f2b79f2dbb513dfc0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->