### PR TITLE
feat: Fix issue categorization follow-up (#20)

### DIFF
--- a/adws/adwPlanBuild.tsx
+++ b/adws/adwPlanBuild.tsx
@@ -28,6 +28,7 @@ import {
   IssueClassSlashCommand,
   WorkflowStage,
   RecoveryState,
+  commitPrefixMap,
 } from './core';
 import {
   fetchGitHubIssue,
@@ -105,11 +106,7 @@ ${issue.body || 'No description provided.'}`;
   return '/feature';
 }
 
-const commitPrefixMap: Record<IssueClassSlashCommand, string> = {
-  '/feature': 'feat:',
-  '/bug': 'fix:',
-  '/chore': 'chore:',
-};
+// commitPrefixMap is now imported from ./core
 
 /**
  * Determines if a stage should be executed based on recovery state.
@@ -301,10 +298,10 @@ async function main(): Promise<void> {
       ctx.issueType = issueType;
     }
 
-    // Step 2: Create feature branch
+    // Step 2: Create branch with appropriate prefix based on issue type
     if (shouldExecuteStage('branch_created', recoveryState)) {
-      log('Creating feature branch...', 'info');
-      branchName = createFeatureBranch(issueNumber, issue.title);
+      log('Creating branch...', 'info');
+      branchName = createFeatureBranch(issueNumber, issue.title, issueType);
       log(`On branch: ${branchName}`, 'success');
       ctx.branchName = branchName;
       postWorkflowComment(issueNumber, 'branch_created', ctx);
@@ -312,7 +309,7 @@ async function main(): Promise<void> {
       log('Skipping branch creation (already completed)', 'info');
       // If we have a branch from recovery state, check it out
       if (recoveryState.branchName) {
-        branchName = createFeatureBranch(issueNumber, issue.title);
+        branchName = createFeatureBranch(issueNumber, issue.title, issueType);
         ctx.branchName = branchName;
       }
     }
@@ -400,7 +397,7 @@ async function main(): Promise<void> {
     // Commit implementation (only if there are changes)
     if (shouldExecuteStage('implementation_committing', recoveryState)) {
       postWorkflowComment(issueNumber, 'implementation_committing', ctx);
-      commitChanges(`feat: implement #${issueNumber} - ${issue.title}`);
+      commitChanges(`${commitPrefixMap[issueType]} implement #${issueNumber} - ${issue.title}`);
     } else {
       log('Skipping implementation commit (already completed)', 'info');
     }

--- a/adws/adwPrReview.tsx
+++ b/adws/adwPrReview.tsx
@@ -17,7 +17,7 @@
  */
 
 import * as fs from 'fs';
-import { log, generateAdwId, ensureLogsDirectory } from './core';
+import { log, generateAdwId, ensureLogsDirectory, commitPrefixMap } from './core';
 import {
   fetchPRDetails,
   checkoutBranch,
@@ -26,6 +26,7 @@ import {
   postPRWorkflowComment,
   PRReviewWorkflowContext,
   getUnaddressedComments,
+  inferIssueTypeFromBranch,
 } from './github';
 import {
   runPrReviewPlanAgent,
@@ -152,11 +153,13 @@ async function main(): Promise<void> {
     ctx.revisionBuildOutput = buildResult.output;
     postPRWorkflowComment(prNumber, 'pr_review_implemented', ctx);
 
-    // Step 9: Commit changes
+    // Step 9: Commit changes with correct prefix based on branch type
     postPRWorkflowComment(prNumber, 'pr_review_committing', ctx);
+    const issueType = inferIssueTypeFromBranch(prDetails.headBranch);
+    const commitPrefix = commitPrefixMap[issueType];
     const commitMsg = issueNumber
-      ? `feat: address PR review comments for #${issueNumber}`
-      : `feat: address PR review comments`;
+      ? `${commitPrefix} address PR review comments for #${issueNumber}`
+      : `${commitPrefix} address PR review comments`;
     commitChanges(commitMsg);
 
     // Step 10: Push to the PR branch

--- a/adws/core/dataTypes.ts
+++ b/adws/core/dataTypes.ts
@@ -10,6 +10,26 @@
 export type IssueClassSlashCommand = '/chore' | '/bug' | '/feature';
 
 /**
+ * Maps issue classification to commit message prefixes.
+ * Following conventional commits specification.
+ */
+export const commitPrefixMap: Record<IssueClassSlashCommand, string> = {
+  '/feature': 'feat:',
+  '/bug': 'fix:',
+  '/chore': 'chore:',
+};
+
+/**
+ * Maps issue classification to branch name prefixes.
+ * Following common Git branching conventions.
+ */
+export const branchPrefixMap: Record<IssueClassSlashCommand, string> = {
+  '/feature': 'feature',
+  '/bug': 'bugfix',
+  '/chore': 'chore',
+};
+
+/**
  * All slash commands used in the ADW system.
  * Includes issue classification commands and ADW-specific commands.
  */

--- a/adws/core/index.ts
+++ b/adws/core/index.ts
@@ -27,6 +27,9 @@ export type {
   RecoveryState,
 } from './dataTypes';
 
+// Prefix maps for consistent branch naming and commit messages
+export { commitPrefixMap, branchPrefixMap } from './dataTypes';
+
 // Utilities
 export {
   generateAdwId,

--- a/adws/github/gitOperations.ts
+++ b/adws/github/gitOperations.ts
@@ -3,7 +3,7 @@
  */
 
 import { execSync } from 'child_process';
-import { log, slugify } from '../core';
+import { log, slugify, IssueClassSlashCommand, branchPrefixMap } from '../core';
 
 /**
  * Gets the current git branch name.
@@ -13,21 +13,49 @@ export function getCurrentBranch(): string {
 }
 
 /**
+ * Generates a branch name from issue number, title, and type.
+ * Format: {prefix}/issue-{number}-{slugified-title}
+ *
+ * @param issueNumber - The GitHub issue number
+ * @param title - The issue title (will be slugified)
+ * @param issueType - The issue classification (defaults to '/feature')
+ * @returns Branch name with appropriate prefix based on issue type
+ */
+export function generateBranchName(
+  issueNumber: number,
+  title: string,
+  issueType: IssueClassSlashCommand = '/feature'
+): string {
+  const slug = slugify(title);
+  const prefix = branchPrefixMap[issueType];
+  return `${prefix}/issue-${issueNumber}-${slug}`;
+}
+
+/**
+ * @deprecated Use generateBranchName instead. This function is kept for backwards compatibility.
  * Generates a feature branch name from issue number and title.
  * Format: feature/issue-{number}-{slugified-title}
  */
 export function generateFeatureBranchName(issueNumber: number, title: string): string {
-  const slug = slugify(title);
-  return `feature/issue-${issueNumber}-${slug}`;
+  return generateBranchName(issueNumber, title, '/feature');
 }
 
 /**
- * Creates and checks out a feature branch for the given issue.
+ * Creates and checks out a branch for the given issue.
+ * The branch prefix is determined by the issue type (feature/, bugfix/, chore/).
  * If the branch already exists, checks it out instead.
+ *
+ * @param issueNumber - The GitHub issue number
+ * @param title - The issue title (will be slugified for branch name)
+ * @param issueType - The issue classification (defaults to '/feature')
  * @returns The branch name.
  */
-export function createFeatureBranch(issueNumber: number, title: string): string {
-  const branchName = generateFeatureBranchName(issueNumber, title);
+export function createFeatureBranch(
+  issueNumber: number,
+  title: string,
+  issueType: IssueClassSlashCommand = '/feature'
+): string {
+  const branchName = generateBranchName(issueNumber, title, issueType);
 
   try {
     const existingBranches = execSync('git branch -a', { encoding: 'utf-8' });
@@ -42,7 +70,7 @@ export function createFeatureBranch(issueNumber: number, title: string): string 
 
     return branchName;
   } catch (error) {
-    throw new Error(`Failed to create feature branch: ${error}`);
+    throw new Error(`Failed to create branch: ${error}`);
   }
 }
 
@@ -110,6 +138,27 @@ export function getDefaultBranch(): string {
   } catch (error) {
     throw new Error(`Failed to get default branch: ${error}`);
   }
+}
+
+/**
+ * Infers the issue type from a branch name by examining its prefix.
+ * Maps branch prefixes to issue classification:
+ *   - bugfix/ -> /bug
+ *   - chore/ -> /chore
+ *   - feature/ (or unknown) -> /feature
+ *
+ * @param branchName - The branch name to parse (e.g., "bugfix/issue-123-fix-login")
+ * @returns The inferred issue type classification
+ */
+export function inferIssueTypeFromBranch(branchName: string): IssueClassSlashCommand {
+  if (branchName.startsWith('bugfix/')) {
+    return '/bug';
+  }
+  if (branchName.startsWith('chore/')) {
+    return '/chore';
+  }
+  // Default to feature for feature/ prefix or unknown prefixes
+  return '/feature';
 }
 
 /**

--- a/adws/github/index.ts
+++ b/adws/github/index.ts
@@ -18,6 +18,7 @@ export {
 // Git Operations
 export {
   getCurrentBranch,
+  generateBranchName,
   generateFeatureBranchName,
   createFeatureBranch,
   checkoutBranch,
@@ -25,6 +26,7 @@ export {
   pushBranch,
   getDefaultBranch,
   checkoutDefaultBranch,
+  inferIssueTypeFromBranch,
 } from './gitOperations';
 
 // Pull Request Creator

--- a/adws/github/prCommentDetector.ts
+++ b/adws/github/prCommentDetector.ts
@@ -22,10 +22,20 @@ export function getLastAdwCommitTimestamp(branchName: string): Date | null {
       { encoding: 'utf-8' }
     );
 
+    // ADW commit patterns for all issue types (feat/fix/chore)
     const adwPatterns = [
+      // Implementation commits
       /feat: implement #/,
+      /fix: implement #/,
+      /chore: implement #/,
+      // PR review commits
       /feat: address PR review/,
+      /fix: address PR review/,
+      /chore: address PR review/,
+      // Implementation plan commits
       /feat: add implementation plan for #/,
+      /fix: add implementation plan for #/,
+      /chore: add implementation plan for #/,
     ];
 
     for (const line of output.split('\n')) {

--- a/adws/github/workflowComments.ts
+++ b/adws/github/workflowComments.ts
@@ -79,10 +79,11 @@ export function extractAdwIdFromComment(commentBody: string): string | null {
 
 /**
  * Extracts the branch name from a comment body.
- * Pattern: `feature/issue-{number}-{slug}`
+ * Supports all branch prefixes: feature/, bugfix/, chore/
+ * Pattern: `{prefix}/issue-{number}-{slug}`
  */
 export function extractBranchNameFromComment(commentBody: string): string | null {
-  const match = commentBody.match(/`(feature\/issue-\d+[a-z0-9-]*)`/);
+  const match = commentBody.match(/`((feature|bugfix|chore)\/issue-\d+[a-z0-9-]*)`/);
   return match ? match[1] : null;
 }
 

--- a/specs/issue-20-plan.md
+++ b/specs/issue-20-plan.md
@@ -1,0 +1,196 @@
+# Bug: Issue categorization not applied to follow-up actions
+
+## Bug Description
+
+When a GitHub issue is processed by the ADW (Agentic Development Workflow) system, the issue is correctly classified as one of three types: `/feature`, `/bug`, or `/chore`. However, the follow-up actions after classification always use "feature" conventions regardless of the actual issue type:
+
+**Symptoms:**
+- Branch names always use `feature/issue-{number}-{slug}` format, even for bugs and chores
+- Implementation commits always use `feat:` prefix instead of `fix:` for bugs or `chore:` for chores
+- PR review commits always use `feat:` prefix
+- Recovery detection only looks for `feat:` commit patterns, potentially missing bug/chore workflows
+
+**Expected Behavior:**
+- Bug issues should create `bugfix/issue-{number}-{slug}` branches with `fix:` commit prefixes
+- Chore issues should create `chore/issue-{number}-{slug}` branches with `chore:` commit prefixes
+- Feature issues should continue using `feature/issue-{number}-{slug}` branches with `feat:` commit prefixes
+- Recovery detection should recognize all commit prefix patterns
+
+**Actual Behavior:**
+- All issues create `feature/` branches regardless of type
+- Implementation commits always use `feat:` prefix (line 403 in adwPlanBuild.tsx)
+- PR review commits always use `feat:` prefix (lines 158-159 in adwPrReview.tsx)
+- Branch name extraction only matches `feature/` pattern (line 85 in workflowComments.ts)
+
+## Problem Statement
+
+The issue classification system correctly identifies issue types but fails to propagate this classification to branch naming and commit messages. This inconsistency causes:
+1. Misleading branch names that don't reflect the nature of the work
+2. Inconsistent git history where all commits appear as features
+3. Potential issues with conventional commit tooling that relies on prefixes
+4. Recovery detection may fail for bug/chore workflows
+
+## Solution Statement
+
+Update the ADW workflow to consistently apply issue classification throughout all follow-up actions:
+1. Create a branch prefix mapping based on issue type (feature/, bugfix/, chore/)
+2. Use the existing `commitPrefixMap` consistently for all commit messages
+3. Update recovery detection patterns to recognize all commit prefixes
+4. Update branch name extraction to match all branch prefix patterns
+
+## Steps to Reproduce
+
+1. Create a GitHub issue with bug-related content (e.g., "Fix login button not working")
+2. Trigger the ADW workflow for this issue
+3. Observe that the issue is classified as `/bug` (visible in GitHub comments)
+4. Check the created branch name - it will be `feature/issue-{number}-{slug}` instead of `bugfix/issue-{number}-{slug}`
+5. Check the implementation commit message - it will use `feat:` instead of `fix:`
+
+## Root Cause Analysis
+
+The root cause is inconsistent application of the `IssueClassSlashCommand` type throughout the workflow:
+
+1. **Branch naming (`gitOperations.ts:19-22`)**: The `generateFeatureBranchName()` function is hardcoded to use `feature/` prefix and doesn't accept an issue type parameter.
+
+2. **Implementation commit (`adwPlanBuild.tsx:403`)**: The implementation commit message is hardcoded to use `feat:` instead of using the `commitPrefixMap` that already exists at line 108-112.
+
+3. **PR review commits (`adwPrReview.tsx:158-159`)**: The PR review commit messages are hardcoded to use `feat:` and don't have access to the original issue type.
+
+4. **Recovery detection (`prCommentDetector.ts:26-28`)**: The ADW commit patterns only look for `feat:` prefixes, missing commits with `fix:` or `chore:` prefixes.
+
+5. **Branch extraction (`workflowComments.ts:85`)**: The regex pattern only matches `feature/` branches, missing `bugfix/` and `chore/` branches.
+
+## Relevant Files
+
+Use these files to fix the bug:
+
+### `adws/github/gitOperations.ts`
+- Contains `generateFeatureBranchName()` function (line 19-22) that hardcodes `feature/` prefix
+- Contains `createFeatureBranch()` function (line 29-47) that calls the generator
+- Needs: Branch prefix mapping and updated function signatures to accept issue type
+
+### `adws/adwPlanBuild.tsx`
+- Contains `commitPrefixMap` (line 108-112) - the mapping already exists
+- Contains hardcoded `feat:` implementation commit (line 403)
+- Needs: Use `commitPrefixMap` for implementation commit instead of hardcoded `feat:`
+
+### `adws/adwPrReview.tsx`
+- Contains hardcoded `feat:` PR review commits (lines 158-159)
+- Needs: Access to issue type and use of commit prefix mapping
+
+### `adws/github/prCommentDetector.ts`
+- Contains ADW commit patterns (lines 26-28) that only match `feat:` prefix
+- Needs: Updated patterns to match `fix:` and `chore:` prefixes as well
+
+### `adws/github/workflowComments.ts`
+- Contains `extractBranchNameFromComment()` (line 84-86) with regex that only matches `feature/`
+- Needs: Updated regex to match `bugfix/` and `chore/` branch prefixes
+
+### `adws/core/dataTypes.ts`
+- Contains `IssueClassSlashCommand` type definition (line 10)
+- Reference file - no changes needed, but used for type safety
+
+## Step by Step Tasks
+
+### Step 1: Add branch prefix mapping to gitOperations.ts
+
+- Add a `branchPrefixMap` constant that maps `IssueClassSlashCommand` to branch prefixes:
+  - `/feature` → `feature`
+  - `/bug` → `bugfix`
+  - `/chore` → `chore`
+- Rename `generateFeatureBranchName()` to `generateBranchName()` and add `issueType` parameter
+- Update the function to use the branch prefix mapping
+- Update `createFeatureBranch()` to accept `issueType` parameter and pass it to the generator
+- Add the `IssueClassSlashCommand` import from core
+
+### Step 2: Update adwPlanBuild.tsx to pass issue type to branch creation
+
+- Update the `createFeatureBranch()` call (line 307) to pass the `issueType` parameter
+- Update the implementation commit (line 403) to use `commitPrefixMap[issueType]` instead of hardcoded `feat:`
+- Ensure `issueType` is available in scope where the implementation commit is made
+
+### Step 3: Update adwPrReview.tsx to use correct commit prefix
+
+- Add logic to extract the issue type from the PR context:
+  - Option A: Extract from the plan file which contains the issue classification
+  - Option B: Parse the branch name to infer the issue type (bugfix/ → bug, chore/ → chore, feature/ → feature)
+- Add the `commitPrefixMap` (or import it from a shared location)
+- Update the commit message (lines 158-159) to use the correct prefix based on issue type
+
+### Step 4: Update prCommentDetector.ts to recognize all commit prefixes
+
+- Update the `adwPatterns` array (lines 25-29) to include patterns for all commit prefixes:
+  - Add `/fix: implement #/` for bug fixes
+  - Add `/chore: implement #/` for chores
+  - Add `/fix: address PR review/` for bug fix PR reviews
+  - Add `/chore: address PR review/` for chore PR reviews
+  - Add `/fix: add implementation plan for #/` for bug fix plans
+  - Add `/chore: add implementation plan for #/` for chore plans
+
+### Step 5: Update workflowComments.ts to extract all branch name patterns
+
+- Update the `extractBranchNameFromComment()` function (line 84-86)
+- Change the regex pattern from `/\`(feature\/issue-\d+[a-z0-9-]*)\`/` to `/\`((feature|bugfix|chore)\/issue-\d+[a-z0-9-]*)\`/`
+- This allows extraction of branch names with any of the three prefixes
+
+### Step 6: Move commitPrefixMap to a shared location
+
+- Move `commitPrefixMap` from `adwPlanBuild.tsx` to `adws/core/dataTypes.ts` or a new shared constants file
+- Export it so it can be imported by both `adwPlanBuild.tsx` and `adwPrReview.tsx`
+- Update imports in both files
+
+### Step 7: Add branchPrefixMap to shared location
+
+- Add `branchPrefixMap` to the same shared location as `commitPrefixMap`
+- Export it for use in `gitOperations.ts` and potentially `workflowComments.ts`
+
+### Step 8: Add utility function to infer issue type from branch name
+
+- Create a helper function `inferIssueTypeFromBranch(branchName: string): IssueClassSlashCommand`
+- This function parses the branch prefix and returns the corresponding issue type
+- Add to `gitOperations.ts` or a shared utility file
+- Use in `adwPrReview.tsx` to determine the commit prefix from the PR's head branch
+
+### Step 9: Run validation commands
+
+- Run `npm run lint` to ensure no linting errors
+- Run `npm run build` to verify no TypeScript/build errors
+- Run `npm test` to ensure no regressions
+
+## Validation Commands
+
+Execute every command to validate the bug is fixed with zero regressions.
+
+- `npm run lint` - Run linter to check for code quality issues
+- `npm run build` - Build the application to verify no build errors
+- `npm test` - Run tests to validate the bug is fixed with zero regressions
+
+### Manual Validation Steps
+
+After running the automated validation commands, manually verify:
+
+1. **Bug Issue Test:**
+   - Create a test issue with bug-related content
+   - Run: `npx tsx adws/adwPlanBuild.tsx <issue-number>` (dry run or on test repo)
+   - Verify branch name starts with `bugfix/`
+   - Verify commits use `fix:` prefix
+
+2. **Chore Issue Test:**
+   - Create a test issue with chore-related content
+   - Run: `npx tsx adws/adwPlanBuild.tsx <issue-number>` (dry run or on test repo)
+   - Verify branch name starts with `chore/`
+   - Verify commits use `chore:` prefix
+
+3. **Feature Issue Test (regression):**
+   - Create a test issue with feature-related content
+   - Verify existing feature behavior is unchanged
+   - Verify branch name starts with `feature/`
+   - Verify commits use `feat:` prefix
+
+## Notes
+
+- The `commitPrefixMap` already exists in `adwPlanBuild.tsx` at lines 108-112. The fix involves using it consistently and sharing it across files.
+- The plan commit (line 343) already correctly uses `commitPrefixMap[issueType]`. Only the implementation commit (line 403) needs fixing.
+- Consider adding unit tests for the new utility functions (`inferIssueTypeFromBranch`, `generateBranchName` with issue type).
+- The branch naming convention follows common Git conventions: `feature/`, `bugfix/`, `chore/`.
+- No new libraries are required for this fix.


### PR DESCRIPTION
## Summary
Implements #20 - Fix issue categorization follow-up

## Implementation Plan
## Summary

I've analyzed GitHub issue #20 and created a comprehensive bug fix plan. Here's what was done:

**Research completed:**
- Explored the ADW (Agentic Development Workflow) codebase structure
- Identified 5 locations where issue classification is not properly propagated
- Analyzed the root cause: hardcoded `feature/` prefixes and `feat:` commit messages
- Reviewed existing `commitPrefixMap` that already exists but isn't used consistently

**Key findings:**
- `generateFeatureBranchName()` in `gitOperations.ts` hardcodes `feature/` prefix
- Implementation commit in `adwPlanBuild.tsx:403` uses hardcoded `feat:` instead of `commitPrefixMap`
- PR review commits in `adwPrReview.tsx:158-159` use hardcoded `feat:`
- Recovery detection patterns in `prCommentDetector.ts` only match `feat:` commits
- Branch extraction regex in `workflowComments.ts` only matches `feature/` branches

**Plan created:**
- **Path:** `specs/issue-20-plan.md`
- Contains 9 step-by-step tasks to fix the bug
- Includes detailed root cause analysis
- Specifies all 6 files that need modification
- Provides validation commands and manual testing steps

## Changes Made
## Implementation Summary

### What was implemented

The issue categorization system now correctly propagates the classification throughout all follow-up actions in the ADW workflow:

1. **Branch naming** - Bug issues create `bugfix/issue-{number}-{slug}` branches, chore issues create `chore/issue-{number}-{slug}` branches, and feature issues use `feature/issue-{number}-{slug}` branches.

2. **Commit prefixes** - All commits now use the correct conventional commit prefix (`feat:`, `fix:`, `chore:`) based on the issue type.

3. **Recovery detection** - The ADW commit patterns now recognize all three commit prefixes for proper workflow recovery.

4. **Branch extraction** - The regex pattern for extracting branch names from comments now supports all three branch prefixes.

### Files changed

| File | Changes |
|------|---------|
| `adws/core/dataTypes.ts` | Added shared `commitPrefixMap` and `branchPrefixMap` constants |
| `adws/core/index.ts` | Added exports for the new prefix maps |
| `adws/github/gitOperations.ts` | Added `generateBranchName()` function with `issueType` parameter, updated `createFeatureBranch()` to accept `issueType`, added `inferIssueTypeFromBranch()` utility |
| `adws/github/index.ts` | Added exports for `generateBranchName` and `inferIssueTypeFromBranch` |
| `adws/adwPlanBuild.tsx` | Updated to use shared `commitPrefixMap`, pass `issueType` to branch creation, use correct prefix for implementation commits |
| `adws/adwPrReview.tsx` | Updated to use `inferIssueTypeFromBranch` and correct commit prefixes for PR review commits |
| `adws/github/prCommentDetector.ts` | Updated `adwPatterns` to recognize `feat:`, `fix:`, and `chore:` prefixes |
| `adws/github/workflowComments.ts` | Updated regex to extract `feature/`, `bugfix/`, and `chore/` branch names |

### Validation results

- **Lint**: ✅ No ESLint warnings or errors
- **Build**: ✅ Compiled successfully, no TypeScript errors
- **Tests**: ✅ All 16 tests passed (2 test files)

### Key implementation details

- The `commitPrefixMap` was moved from `adwPlanBuild.tsx` to `adws/core/dataTypes.ts` for shared access
- A new `branchPrefixMap` was created to map issue types to branch prefixes
- The `inferIssueTypeFromBranch()` utility function parses branch names to determine the issue type (useful for PR review workflow)
- Backwards compatibility is maintained through the existing `generateFeatureBranchName()` function (marked as deprecated)

## Testing
- [ ] All validation commands from the plan pass
- [ ] No regressions introduced
- [ ] Code follows project conventions

---
Generated by ADW Plan & Build workflow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches automated git branching/commit and workflow recovery heuristics; incorrect prefix/regex logic could cause branch naming changes or missed recovery detection in existing workflows.
> 
> **Overview**
> Ensures ADW issue classification is consistently applied after classification: bug and chore issues now create `bugfix/` and `chore/` branches (instead of always `feature/`), and both implementation and PR-review commits use the matching conventional commit prefix (`fix:`/`chore:`/`feat:`).
> 
> Centralizes prefix mappings in `core` (`commitPrefixMap`, new `branchPrefixMap`), adds branch name generation and `inferIssueTypeFromBranch()` utilities, expands recovery detection patterns to recognize all three commit prefixes, and updates workflow comment parsing to extract non-`feature/` branches.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d41591aedfde41154cebf0736873c3d5ec81ab8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->