### PR TITLE
feat: Agent invocation is incorrect (#28)

### DIFF
--- a/adws/adwPlanBuild.tsx
+++ b/adws/adwPlanBuild.tsx
@@ -48,13 +48,14 @@ import {
   getPlanFilePath,
   planFileExists,
   runBuildAgent,
-  runClaudeAgent,
+  runClaudeAgentWithCommand,
   ProgressCallback,
   ProgressInfo,
 } from './agents';
 
 /**
  * Classifies a GitHub issue as feature, bug, or chore using the haiku model.
+ * Uses the /classify_issue slash command from .claude/commands/classify_issue.md
  */
 async function classifyIssue(
   issue: GitHubIssue,
@@ -63,32 +64,23 @@ async function classifyIssue(
 ): Promise<IssueClassSlashCommand> {
   const labelsText = issue.labels.map(l => l.name).join(', ') || 'none';
 
-  const prompt = `Based on the Github Issue below, follow the Instructions to select the appropriate command to execute based on the Command Mapping.
-
-## Instructions
-
-- Based on the details in the Github Issue, select the appropriate command to execute.
-- Respond exclusively with '/' followed by the command to execute.
-- Use the command mapping to help you decide which command to respond with.
-- Think hard about the command to execute.
-
-## Command Mapping
-
-- Respond with /chore if the issue is a chore.
-- Respond with /bug if the issue is a bug.
-- Respond with /feature if the issue is a feature.
-- Respond with /pr_review if the issue is requesting a PR review, code review, or review-related changes.
-- Respond with 0 if the issue isn't any of the above.
-
-## Github Issue
-
-**Title:** ${issue.title}
+  // Format the issue context as arguments for the /classify_issue command
+  // This matches the $ARGUMENTS placeholder in classify_issue.md
+  const args = `**Title:** ${issue.title}
 **Labels:** ${labelsText}
 
 ${issue.body || 'No description provided.'}`;
 
   const outputFile = path.join(logsDir, 'classifier-agent.jsonl');
-  const result = await runClaudeAgent(prompt, 'Classifier', outputFile, 'haiku', undefined, statePath);
+  const result = await runClaudeAgentWithCommand(
+    '/classify_issue',
+    args,
+    'Classifier',
+    outputFile,
+    'haiku',
+    undefined,
+    statePath
+  );
 
   if (!result.success) {
     log('Classification failed, defaulting to /feature', 'info');

--- a/adws/adwPrReview.tsx
+++ b/adws/adwPrReview.tsx
@@ -207,7 +207,6 @@ async function main(): Promise<void> {
 
     const buildResult = await runPrReviewBuildAgent(
       prDetails,
-      unaddressedComments,
       planResult.output,
       logsDir,
       buildProgressCallback,

--- a/adws/agents/buildAgent.ts
+++ b/adws/agents/buildAgent.ts
@@ -1,116 +1,64 @@
 /**
  * Build Agent - Implements solutions based on implementation plans.
+ * Uses the /implement slash command from .claude/commands/implement.md
  */
 
 import * as path from 'path';
-import { GitHubIssue, PRDetails, PRReviewComment, log } from '../core';
-import { runClaudeAgent, AgentResult, ProgressCallback } from './claudeAgent';
+import { GitHubIssue, PRDetails, log } from '../core';
+import { runClaudeAgentWithCommand, AgentResult, ProgressCallback } from './claudeAgent';
 
 /**
- * Builds the prompt for the Build Agent.
+ * Formats the plan content as arguments for the /implement command.
+ * Includes issue context to provide additional information to the agent.
  */
-export function buildImplementPrompt(issue: GitHubIssue, planContent: string): string {
-  return `You are a Build Agent. Your job is to implement the solution based on the implementation plan below.
-
-## GitHub Issue #${issue.number}
+function formatImplementArgs(issue: GitHubIssue, planContent: string): string {
+  return `## GitHub Issue #${issue.number}
 **Title:** ${issue.title}
 **URL:** ${issue.url}
 
 ## Implementation Plan
-${planContent}
-
-## Instructions
-
-1. Follow the implementation plan step-by-step
-2. Make all necessary code changes as specified in the plan
-3. Run the validation commands from the plan to verify correctness
-4. Ensure all tests pass and there are no regressions
-
-## After Implementation
-Provide a summary of:
-- What was implemented
-- Files changed/created
-- Validation results
-- Any issues encountered and how they were resolved
-
-IMPORTANT: Follow the plan exactly. Run validation commands to verify the implementation.`;
+${planContent}`;
 }
 
 /**
- * Formats PR review comments for inclusion in a build prompt.
+ * Formats the revision plan as arguments for the /implement command.
+ * Includes PR context to provide additional information to the agent.
  */
-function formatPrReviewComments(comments: PRReviewComment[]): string {
-  return comments
-    .map(c => {
-      const location = c.path
-        ? `**File:** \`${c.path}\`${c.line ? ` (line ${c.line})` : ''}`
-        : '**General comment**';
-      return `${location}\n**Author:** ${c.author.login}\n**Comment:** ${c.body}`;
-    })
-    .join('\n\n---\n\n');
-}
-
-/**
- * Builds the prompt for the Build Agent to address PR review comments.
- */
-export function buildPrReviewImplementPrompt(
-  prDetails: PRDetails,
-  comments: PRReviewComment[],
-  revisionPlan: string
-): string {
-  const commentsSection = formatPrReviewComments(comments);
-
-  return `You are a Build Agent. Your job is to implement changes to address PR review comments.
-
-## PR #${prDetails.number}: ${prDetails.title}
+function formatPrReviewImplementArgs(prDetails: PRDetails, revisionPlan: string): string {
+  return `## PR #${prDetails.number}: ${prDetails.title}
 **URL:** ${prDetails.url}
 **Branch:** ${prDetails.headBranch}
 
-## PR Review Comments to Address
-${commentsSection}
-
 ## Revision Plan
-${revisionPlan}
-
-## Instructions
-
-1. Follow the revision plan to address each review comment
-2. Make all necessary code changes
-3. Run validation commands to verify correctness
-4. Ensure no regressions are introduced
-
-## After Implementation
-Provide a summary of what was changed to address each review comment.
-
-IMPORTANT: Follow the revision plan exactly. Only make changes that address the review comments.`;
+${revisionPlan}`;
 }
 
 /**
  * Runs the Build Agent to implement PR review changes.
+ * Uses the /implement slash command with the revision plan as arguments.
  */
 export async function runPrReviewBuildAgent(
   prDetails: PRDetails,
-  comments: PRReviewComment[],
   revisionPlan: string,
   logsDir: string,
   onProgress?: ProgressCallback,
   statePath?: string
 ): Promise<AgentResult> {
-  const prompt = buildPrReviewImplementPrompt(prDetails, comments, revisionPlan);
+  const args = formatPrReviewImplementArgs(prDetails, revisionPlan);
   const outputFile = path.join(logsDir, 'pr-review-build-agent.jsonl');
 
   log('PR Review Build Agent starting with arguments:', 'info');
   log(`  PR: #${prDetails.number} - ${prDetails.title}`, 'info');
-  log(`  Review comments: ${comments.length}`, 'info');
   log(`  Output file: ${outputFile}`, 'info');
   log(`  Revision plan length: ${revisionPlan.length} characters`, 'info');
   log(`  Model: opus`, 'info');
 
-  return runClaudeAgent(prompt, 'PR Review Build', outputFile, 'opus', onProgress, statePath);
+  return runClaudeAgentWithCommand('/implement', args, 'PR Review Build', outputFile, 'opus', onProgress, statePath);
 }
 
 /**
  * Runs the Build Agent to implement the solution.
+ * Uses the /implement slash command with the plan content as arguments.
  */
 export async function runBuildAgent(
   issue: GitHubIssue,
@@ -119,7 +67,7 @@ export async function runBuildAgent(
   onProgress?: ProgressCallback,
   statePath?: string
 ): Promise<AgentResult> {
-  const prompt = buildImplementPrompt(issue, planContent);
+  const args = formatImplementArgs(issue, planContent);
   const outputFile = path.join(logsDir, 'build-agent.jsonl');
 
   // Log the arguments with which the agent is started
@@ -130,5 +78,5 @@ export async function runBuildAgent(
   log(`  Plan content length: ${planContent.length} characters`, 'info');
   log(`  Model: opus`, 'info');
 
-  return runClaudeAgent(prompt, 'Build', outputFile, 'opus', onProgress, statePath);
+  return runClaudeAgentWithCommand('/implement', args, 'Build', outputFile, 'opus', onProgress, statePath);
 }

--- a/adws/agents/claudeAgent.ts
+++ b/adws/agents/claudeAgent.ts
@@ -267,3 +267,146 @@ export async function runClaudeAgent(
     });
   });
 }
+
+/**
+ * Runs a Claude Code agent with a slash command.
+ * The command is passed as a CLI argument rather than via stdin.
+ *
+ * @param command - The slash command to invoke (e.g., '/implement', '/feature')
+ * @param args - Arguments to pass to the command (replaces $ARGUMENTS)
+ * @param agentName - Human-readable name for logging
+ * @param outputFile - Path to write JSONL output
+ * @param model - The model to use ('opus', 'sonnet', 'haiku')
+ * @param onProgress - Optional callback for progress updates
+ * @param statePath - Optional path to agent's state directory for state tracking
+ */
+export async function runClaudeAgentWithCommand(
+  command: string,
+  args: string,
+  agentName: string,
+  outputFile: string,
+  model: string = 'sonnet',
+  onProgress?: ProgressCallback,
+  statePath?: string
+): Promise<AgentResult> {
+  // Build the prompt as "command 'args'" for the CLI
+  // The args are single-quoted to preserve formatting
+  const prompt = `${command} '${args.replace(/'/g, "'\\''")}'`;
+
+  // Write initial state if state path provided
+  if (statePath) {
+    AgentStateManager.appendLog(statePath, `Starting ${agentName} agent with command: ${command}`, prompt);
+    AgentStateManager.appendLog(statePath, `Model: ${model}`);
+  }
+
+  return new Promise((resolve) => {
+    const cliArgs = [
+      '--print',
+      '--verbose',
+      '--dangerously-skip-permissions',
+      '--output-format', 'stream-json',
+      '--model', model,
+      prompt
+    ];
+
+    log(`Starting ${agentName} agent...`, 'info');
+    log(`  Command: ${CLAUDE_CODE_PATH} ${cliArgs.slice(0, -1).join(' ')} "<prompt>"`, 'info');
+    log(`  Slash command: ${command}`, 'info');
+    log(`  Model: ${model}`, 'info');
+    log(`  Output file: ${outputFile}`, 'info');
+    log(`  Args length: ${args.length} characters`, 'info');
+
+    const claude = spawn(CLAUDE_CODE_PATH, cliArgs, {
+      cwd: process.cwd(),
+      env: { ...process.env }
+    });
+
+    const state = {
+      lastResult: null as ClaudeCodeResultMessage | null,
+      fullOutput: '',
+      turnCount: 0,
+      toolCount: 0,
+    };
+
+    const outputStream = fs.createWriteStream(outputFile, { flags: 'a' });
+
+    claude.stdout.on('data', (data: Buffer) => {
+      const text = data.toString();
+      outputStream.write(text);
+      parseJsonlOutput(text, state, onProgress, statePath);
+    });
+
+    claude.stderr.on('data', (data: Buffer) => {
+      const text = data.toString();
+      outputStream.write(`[STDERR] ${text}`);
+      log(`${agentName} stderr: ${text}`, 'error');
+    });
+
+    claude.on('close', (code) => {
+      outputStream.end();
+
+      // Log final summary
+      log(`${agentName} agent finished:`, 'info');
+      log(`  Exit code: ${code}`, 'info');
+      log(`  Total turns: ${state.turnCount}`, 'info');
+      log(`  Total tool calls: ${state.toolCount}`, 'info');
+
+      if (onProgress) {
+        onProgress({
+          type: 'summary',
+          turnCount: state.turnCount,
+          toolCount: state.toolCount,
+        });
+      }
+
+      // Write final state summary if statePath provided
+      if (statePath) {
+        AgentStateManager.appendLog(
+          statePath,
+          `Completed: exit code ${code}, turns: ${state.turnCount}, tools: ${state.toolCount}`
+        );
+      }
+
+      if (code === 0 && state.lastResult) {
+        log(`${agentName} completed successfully`, 'success');
+        if (state.lastResult.totalCostUsd) {
+          log(`  Cost: $${state.lastResult.totalCostUsd.toFixed(4)}`, 'info');
+        }
+        resolve({
+          success: !state.lastResult.isError,
+          output: state.lastResult.result || state.fullOutput,
+          sessionId: state.lastResult.sessionId,
+          totalCostUsd: state.lastResult.totalCostUsd,
+          statePath
+        });
+      } else if (code === 0) {
+        resolve({
+          success: true,
+          output: state.fullOutput,
+          statePath
+        });
+      } else {
+        log(`${agentName} exited with code ${code}`, 'error');
+        resolve({
+          success: false,
+          output: state.fullOutput || 'Agent failed without output',
+          statePath
+        });
+      }
+    });
+
+    claude.on('error', (error) => {
+      outputStream.end();
+      log(`${agentName} error: ${error.message}`, 'error');
+      // Log error to state if statePath provided
+      if (statePath) {
+        AgentStateManager.appendLog(statePath, `Error: ${error.message}`);
+      }
+      resolve({
+        success: false,
+        output: error.message,
+        statePath
+      });
+    });
+  });
+}

--- a/adws/agents/index.ts
+++ b/adws/agents/index.ts
@@ -1,10 +1,12 @@
 /**
  * Agents module - Claude Code agent runners.
+ * All agents use slash commands from .claude/commands/ for consistent prompt templates.
  */
 
-// Claude Agent (base runner)
+// Claude Agent (base runners)
 export {
   runClaudeAgent,
+  runClaudeAgentWithCommand,
   type AgentResult,
   type ProgressInfo,
   type ProgressCallback,
@@ -12,18 +14,14 @@ export {
 
 // Plan Agent
 export {
-  buildPlanPrompt,
   getPlanFilePath,
   planFileExists,
-  buildPrReviewPlanPrompt,
   runPrReviewPlanAgent,
   runPlanAgent,
 } from './planAgent';
 
 // Build Agent
 export {
-  buildImplementPrompt,
-  buildPrReviewImplementPrompt,
   runPrReviewBuildAgent,
   runBuildAgent,
 } from './buildAgent';

--- a/adws/agents/planAgent.ts
+++ b/adws/agents/planAgent.ts
@@ -1,24 +1,25 @@
 /**
  * Plan Agent - Generates implementation plans from GitHub issues.
+ * Uses slash commands from .claude/commands/ for consistent prompt templates.
  */
 
 import * as fs from 'fs';
 import * as path from 'path';
 import { GitHubIssue, IssueClassSlashCommand, PRDetails, PRReviewComment } from '../core';
-import { runClaudeAgent, AgentResult } from './claudeAgent';
+import { runClaudeAgentWithCommand, AgentResult } from './claudeAgent';
 
 /**
- * Formats issue context for the plan prompt.
+ * Formats issue context as arguments for plan commands.
+ * This creates the full context that replaces $ARGUMENTS in the command templates.
  */
-function formatIssueContext(issue: GitHubIssue): string {
+function formatIssueContextAsArgs(issue: GitHubIssue): string {
   const commentsSection = issue.comments.length > 0
     ? issue.comments
         .map(c => `**${c.author.login}** (${c.createdAt}):\n${c.body}`)
         .join('\n\n---\n\n')
     : 'No comments.';
 
-  return `
-## GitHub Issue #${issue.number}
+  return `## GitHub Issue #${issue.number}
 **Title:** ${issue.title}
 **State:** ${issue.state}
 **Author:** ${issue.author.login}
@@ -29,40 +30,7 @@ function formatIssueContext(issue: GitHubIssue): string {
 ${issue.body || 'No description provided.'}
 
 ### Comments
-${commentsSection}
-`.trim();
-}
-
-/**
- * Builds the prompt for the Plan Agent.
- */
-export function buildPlanPrompt(issue: GitHubIssue, issueType: IssueClassSlashCommand = '/feature'): string {
-  const issueContext = formatIssueContext(issue);
-
-  return `You are a Plan Agent. Your job is to analyze the following GitHub issue and create a detailed implementation plan.
-
-${issueContext}
-
-## Instructions
-
-1. Analyze the issue requirements carefully
-2. Research the codebase to understand existing patterns and architecture
-3. Create a comprehensive implementation plan in specs/issue-${issue.number}-plan.md
-
-Use the ${issueType} command format to create the plan. The plan should include:
-- Feature description
-- User story
-- Problem and solution statements
-- Relevant files (existing and new)
-- Implementation phases
-- Step-by-step tasks
-- Testing strategy
-- Acceptance criteria
-- Validation commands
-
-After creating the plan, provide a brief summary of what the plan covers.
-
-IMPORTANT: Focus only on planning. Do not implement any code changes. Create the plan file and summarize it.`;
+${commentsSection}`;
 }
 
 /**
@@ -101,18 +69,16 @@ function formatPrReviewComments(comments: PRReviewComment[]): string {
 }
 
 /**
- * Builds the prompt for the Plan Agent to address PR review comments.
+ * Formats PR review context as arguments for the /pr_review command.
  */
-export function buildPrReviewPlanPrompt(
+function formatPrReviewContextAsArgs(
   prDetails: PRDetails,
   comments: PRReviewComment[],
   existingPlanContent: string
 ): string {
   const commentsSection = formatPrReviewComments(comments);
 
-  return `You are a Plan Agent. Your job is to create a revision plan to address PR review comments.
-
-## PR #${prDetails.number}: ${prDetails.title}
+  return `## PR #${prDetails.number}: ${prDetails.title}
 **URL:** ${prDetails.url}
 **Branch:** ${prDetails.headBranch}
 
@@ -120,23 +86,12 @@ export function buildPrReviewPlanPrompt(
 ${existingPlanContent}
 
 ## PR Review Comments to Address
-${commentsSection}
-
-## Instructions
-
-1. Analyze each review comment carefully
-2. Research the codebase to understand the context of each comment
-3. Create a revision plan that addresses ALL review comments
-4. The revision plan should be specific about what files to change and how
-5. Include validation commands to verify the changes
-
-Output the revision plan as markdown. Focus only on the changes needed to address the review comments — do not re-implement the entire feature.
-
-IMPORTANT: Focus only on planning. Do not implement any code changes.`;
+${commentsSection}`;
 }
 
 /**
  * Runs the Plan Agent to create a revision plan for PR review comments.
+ * Uses the /pr_review slash command from .claude/commands/pr_review.md
  */
 export async function runPrReviewPlanAgent(
   prDetails: PRDetails,
@@ -145,14 +100,15 @@ export async function runPrReviewPlanAgent(
   logsDir: string,
   statePath?: string
 ): Promise<AgentResult> {
-  const prompt = buildPrReviewPlanPrompt(prDetails, comments, existingPlanContent);
+  const args = formatPrReviewContextAsArgs(prDetails, comments, existingPlanContent);
   const outputFile = path.join(logsDir, 'pr-review-plan-agent.jsonl');
 
-  return runClaudeAgent(prompt, 'PR Review Plan', outputFile, 'opus', undefined, statePath);
+  return runClaudeAgentWithCommand('/pr_review', args, 'PR Review Plan', outputFile, 'opus', undefined, statePath);
 }
 
 /**
  * Runs the Plan Agent to generate an implementation plan.
+ * Uses the appropriate slash command (/feature, /bug, /chore, /pr_review) based on issue type.
  */
 export async function runPlanAgent(
   issue: GitHubIssue,
@@ -160,8 +116,9 @@ export async function runPlanAgent(
   issueType: IssueClassSlashCommand = '/feature',
   statePath?: string
 ): Promise<AgentResult> {
-  const prompt = buildPlanPrompt(issue, issueType);
+  const args = formatIssueContextAsArgs(issue);
   const outputFile = path.join(logsDir, 'plan-agent.jsonl');
 
-  return runClaudeAgent(prompt, 'Plan', outputFile, 'opus', undefined, statePath);
+  // Use the issueType directly as the command (e.g., '/feature', '/bug', '/chore', '/pr_review')
+  return runClaudeAgentWithCommand(issueType, args, 'Plan', outputFile, 'opus', undefined, statePath);
 }

--- a/adws/index.ts
+++ b/adws/index.ts
@@ -39,19 +39,17 @@ export {
 } from './core';
 
 // Agents module - Claude Code agent runners
+// All agents use slash commands from .claude/commands/ for consistent prompt templates
 export {
   runClaudeAgent,
+  runClaudeAgentWithCommand,
   type AgentResult,
   type ProgressInfo,
   type ProgressCallback,
-  buildPlanPrompt,
   getPlanFilePath,
   planFileExists,
-  buildPrReviewPlanPrompt,
   runPrReviewPlanAgent,
   runPlanAgent,
-  buildImplementPrompt,
-  buildPrReviewImplementPrompt,
   runPrReviewBuildAgent,
   runBuildAgent,
 } from './agents';

--- a/specs/issue-28-plan.md
+++ b/specs/issue-28-plan.md
@@ -1,0 +1,154 @@
+# Chore: Refactor Agent Invocation to Use Slash Commands
+
+## Chore Description
+Currently, in the ADW process, agents are started using dedicated inline prompts built in TypeScript code. This is incorrect as it duplicates logic that already exists in the `.claude/commands/` directory. All agents should be invoked using slash commands from `.claude/commands/` to ensure consistency, maintainability, and single-source-of-truth for agent prompts.
+
+The current implementation has three problematic patterns:
+1. **Plan agents** are invoked through `planAgent.ts` with `buildPlanPrompt()` which builds a custom prompt
+2. **Build agents** are invoked through `buildAgent.ts` with `buildImplementPrompt()` which builds a custom prompt
+3. **Classifier** is invoked inline in `adwPlanBuild.tsx::classifyIssue()` with a hardcoded prompt
+
+The target state is:
+- Plan agents use `/bug`, `/chore`, `/feature`, or `/pr_review` commands
+- Build agents use `/implement` command
+- Classifiers use `/classify_issue` command
+
+The model should be passed as a parameter since different commands require different models (e.g., classifier uses `haiku`, plan/build use `opus`).
+
+## Relevant Files
+Use these files to resolve the chore:
+
+- `adws/agents/claudeAgent.ts` - Contains the base `runClaudeAgent()` function that spawns the Claude CLI. Needs to be refactored to support slash command invocation instead of stdin prompts.
+- `adws/agents/planAgent.ts` - Contains `runPlanAgent()` and `buildPlanPrompt()`. The prompt builder will be removed and the runner will use slash commands.
+- `adws/agents/buildAgent.ts` - Contains `runBuildAgent()` and `buildImplementPrompt()`. The prompt builder will be removed and the runner will use slash commands.
+- `adws/agents/index.ts` - Exports from agent modules. May need to remove prompt builder exports.
+- `adws/adwPlanBuild.tsx` - Contains `classifyIssue()` which builds inline prompts. Needs to use `/classify_issue` command.
+- `adws/adwPrReview.tsx` - Uses `runPrReviewPlanAgent()` and `runPrReviewBuildAgent()`. These need to use appropriate slash commands.
+- `.claude/commands/classify_issue.md` - The `/classify_issue` command template.
+- `.claude/commands/implement.md` - The `/implement` command template.
+- `.claude/commands/feature.md` - The `/feature` command template for feature planning.
+- `.claude/commands/bug.md` - The `/bug` command template for bug planning.
+- `.claude/commands/chore.md` - The `/chore` command template for chore planning.
+- `.claude/commands/pr_review.md` - The `/pr_review` command template for PR review planning.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### Step 1: Create a New Command-Based Agent Runner in claudeAgent.ts
+
+- Add a new function `runClaudeAgentWithCommand()` that invokes Claude CLI with a slash command
+- The function signature should be:
+  ```typescript
+  export async function runClaudeAgentWithCommand(
+    command: string,           // e.g., '/implement', '/feature', '/classify_issue'
+    args: string,              // Arguments to pass to the command (replaces $ARGUMENTS)
+    agentName: string,         // Human-readable name for logging
+    outputFile: string,        // Path to write JSONL output
+    model: string,             // Model to use ('opus', 'sonnet', 'haiku')
+    onProgress?: ProgressCallback,
+    statePath?: string
+  ): Promise<AgentResult>
+  ```
+- The function should build the CLI invocation as:
+  ```
+  claude -p --verbose --dangerously-skip-permissions --output-format stream-json --model <model> "<command> '<args>'"
+  ```
+- Keep the existing `runClaudeAgent()` function for backwards compatibility during transition
+
+### Step 2: Update Classifier to Use /classify_issue Command
+
+- In `adws/adwPlanBuild.tsx`, update the `classifyIssue()` function
+- Replace the inline prompt building with a call to `runClaudeAgentWithCommand()`
+- Use command `/classify_issue` with the issue context as arguments
+- Format the arguments to match what `classify_issue.md` expects:
+  ```
+  **Title:** ${issue.title}
+  **Labels:** ${labelsText}
+
+  ${issue.body || 'No description provided.'}
+  ```
+- Use model `haiku` for classification (fast and cost-effective)
+
+### Step 3: Update Plan Agent to Use Planning Commands
+
+- In `adws/agents/planAgent.ts`, update `runPlanAgent()` function
+- Map the `issueType` parameter to the corresponding command:
+  - `/feature` -> `/feature`
+  - `/bug` -> `/bug`
+  - `/chore` -> `/chore`
+  - `/pr_review` -> `/pr_review`
+- Format the arguments to include full issue context (issue number, title, state, author, labels, description, comments)
+- Use model `opus` for planning (complex reasoning needed)
+- Remove or deprecate `buildPlanPrompt()` function after verifying the new approach works
+
+### Step 4: Update Build Agent to Use /implement Command
+
+- In `adws/agents/buildAgent.ts`, update `runBuildAgent()` function
+- Use command `/implement` with the plan file path as argument
+- The argument should be the path to the plan file: `specs/issue-{number}-plan.md`
+- Use model `opus` for implementation
+- Remove or deprecate `buildImplementPrompt()` function after verifying the new approach works
+
+### Step 5: Update PR Review Plan Agent
+
+- In `adws/agents/planAgent.ts`, update `runPrReviewPlanAgent()` function
+- Use command `/pr_review` with formatted PR and comment context as arguments
+- Format arguments to include:
+  - PR number, title, URL, branch
+  - Original plan content
+  - All review comments with file locations
+- Use model `opus` for PR review planning
+- Remove or deprecate `buildPrReviewPlanPrompt()` function
+
+### Step 6: Update PR Review Build Agent
+
+- In `adws/agents/buildAgent.ts`, update `runPrReviewBuildAgent()` function
+- Use command `/implement` with the revision plan as argument
+- Use model `opus` for implementation
+- Remove or deprecate `buildPrReviewImplementPrompt()` function
+
+### Step 7: Update Agent Module Exports
+
+- In `adws/agents/index.ts`, update exports
+- Export the new `runClaudeAgentWithCommand()` function
+- Optionally mark or remove exports for deprecated prompt builders
+- Ensure backwards compatibility for any external callers
+
+### Step 8: Clean Up Deprecated Code
+
+- Remove the following functions that are no longer needed:
+  - `buildPlanPrompt()` from `planAgent.ts`
+  - `buildImplementPrompt()` from `buildAgent.ts`
+  - `buildPrReviewPlanPrompt()` from `planAgent.ts`
+  - `buildPrReviewImplementPrompt()` from `buildAgent.ts`
+- Remove the inline prompt from `classifyIssue()` in `adwPlanBuild.tsx`
+- Update any tests that reference the removed functions
+
+### Step 9: Run Validation Commands
+
+- Execute all validation commands to ensure the refactoring is complete with zero regressions
+
+## Validation Commands
+Execute every command to validate the chore is complete with zero regressions.
+
+- `npm run lint` - Run linter to check for code quality issues
+- `npm run build` - Build the application to verify no build errors
+- `npm test` - Run tests to validate the chore is complete with zero regressions
+- `npx tsx adws/healthCheck.tsx` - Run ADW health check to ensure agent infrastructure is working
+
+## Notes
+
+- **Model Selection**: Different agents require different models:
+  - Classifier: `haiku` (fast, cost-effective for simple classification)
+  - Plan agents: `opus` (complex reasoning and planning)
+  - Build agents: `opus` (complex implementation and code generation)
+
+- **Command Argument Format**: The slash commands expect arguments in a specific format based on their `$ARGUMENTS` placeholder. Care must be taken to format the arguments correctly for each command type.
+
+- **Backwards Compatibility**: During the transition, both the old `runClaudeAgent()` and new `runClaudeAgentWithCommand()` functions should coexist. This allows for gradual migration and rollback if needed.
+
+- **PR Review Workflow**: The PR review workflow (`adwPrReview.tsx`) also needs to be updated to use the new command-based invocation. This includes both the plan and build phases of PR review processing.
+
+- **Testing Approach**: Since the ADW scripts interact with external services (GitHub, Claude CLI), integration testing should be done carefully. Consider testing with a known issue to verify end-to-end functionality.
+
+- **State Management**: The existing state management and progress tracking mechanisms should continue to work with the new command-based invocation. No changes to `AgentStateManager` are needed.


### PR DESCRIPTION
## Summary
Implements #28 - Agent invocation is incorrect

## Implementation Plan
## Report

**Work Completed:**

- Researched the codebase to understand the current agent invocation patterns
- Identified three problematic patterns: planAgent.ts custom prompts, buildAgent.ts custom prompts, and inline classifier in adwPlanBuild.tsx
- Analyzed the `.claude/commands/` directory to understand the expected command formats and `$ARGUMENTS` placeholders
- Created a comprehensive implementation plan with 9 step-by-step tasks covering:
  1. Creating a new `runClaudeAgentWithCommand()` function in claudeAgent.ts
  2. Updating the classifier to use `/classify_issue` command
  3. Updating plan agents to use `/bug`, `/chore`, `/feature`, `/pr_review` commands
  4. Updating build agents to use `/implement` command
  5. Updating PR review plan agent to use `/pr_review` command
  6. Updating PR review build agent to use `/implement` command
  7. Updating agent module exports
  8. Cleaning up deprecated prompt builder functions
  9. Running validation commands
- Documented model selection requirements (haiku for classifier, opus for plan/build)
- Included notes on backwards compatibility, testing approach, and state management

**Plan Location:** `specs/issue-28-plan.md`

## Changes Made
All validation commands have passed. The health check warning about `ANTHROPIC_API_KEY` is an environment configuration issue, not a code issue - all infrastructure components are working correctly.

## Summary

### What was implemented

I refactored the ADW agent invocation system to use slash commands from `.claude/commands/` instead of inline prompts, following the implementation plan:

1. **Created `runClaudeAgentWithCommand()` in `claudeAgent.ts`** - A new function that invokes Claude CLI with a slash command as a CLI argument instead of via stdin. The command format is `<command> '<args>'` where args replaces `$ARGUMENTS` in the command template.

2. **Updated `classifyIssue()` in `adwPlanBuild.tsx`** - Now uses `/classify_issue` command with the issue context formatted to match `classify_issue.md` expectations.

3. **Updated `runPlanAgent()` in `planAgent.ts`** - Now uses the issue type directly as the command (`/feature`, `/bug`, `/chore`, `/pr_review`) with full issue context as arguments.

4. **Updated `runBuildAgent()` in `buildAgent.ts`** - Now uses `/implement` command with the plan content and issue context as arguments.

5. **Updated `runPrReviewPlanAgent()` in `planAgent.ts`** - Now uses `/pr_review` command with PR and review comment context as arguments.

6. **Updated `runPrReviewBuildAgent()` in `buildAgent.ts`** - Now uses `/implement` command with the revision plan as arguments. Simplified signature to remove redundant `comments` parameter.

7. **Updated `adwPrReview.tsx`** - Adjusted call to `runPrReviewBuildAgent` to match new signature.

8. **Cleaned up deprecated code** - Removed `buildPlanPrompt`, `buildImplementPrompt`, `buildPrReviewPlanPrompt`, and `buildPrReviewImplementPrompt` functions and their exports.

### Files changed

- `adws/agents/claudeAgent.ts` - Added `runClaudeAgentWithCommand()` function
- `adws/agents/planAgent.ts` - Updated to use command-based invocation, removed deprecated prompt builders
- `adws/agents/buildAgent.ts` - Updated to use command-based invocation, removed deprecated prompt builders
- `adws/agents/index.ts` - Updated exports to include new function and remove deprecated exports
- `adws/adwPlanBuild.tsx` - Updated `classifyIssue()` to use `/classify_issue` command
- `adws/adwPrReview.tsx` - Updated call to `runPrReviewBuildAgent` with new signature
- `adws/index.ts` - Updated exports to match `agents/index.ts`

### Validation results

- `npm run lint` - ✅ No ESLint warnings or errors
- `npm run build` - ✅ Build successful
- `npm test` - ✅ 46 tests passed (3 test files)
- `npx tsx adws/healthCheck.tsx 28` - ✅ Infrastructure checks pass (env var warning is configuration issue, not code)

### Key design decisions

- **Model selection preserved**: Each agent type uses the appropriate model (classifier uses `haiku`, plan/build use `opus`)
- **Backwards compatibility**: `runClaudeAgent()` is kept for any external callers
- **Single quotes for args**: Arguments are single-quoted with proper escaping to preserve formatting when passed to CLI
- **Simplified PR review build signature**: Removed `comments` parameter from `runPrReviewBuildAgent` since the revision plan already contains all needed context

## Testing
- [ ] All validation commands from the plan pass
- [ ] No regressions introduced
- [ ] Code follows project conventions

---
Generated by ADW Plan & Build workflow
