### PR TITLE
feat: Split adwPlanBuild (#32)

### DIFF
--- a/adws/adwBuild.tsx
+++ b/adws/adwBuild.tsx
@@ -1,0 +1,384 @@
+#!/usr/bin/env npx tsx
+/**
+ * ADW Build - AI Developer Workflow Implementation Phase
+ *
+ * Usage: npx tsx adws/adwBuild.tsx <github-issue-number> [adw-id]
+ *
+ * Workflow:
+ * 1. Fetch GitHub issue details
+ * 2. Verify plan file exists
+ * 3. Infer issue type from current branch
+ * 4. Run Build Agent: Implement the solution
+ * 5. Commit the implementation
+ * 6. Create PR with full context
+ *
+ * Prerequisites:
+ * - Must be on a feature/bugfix/chore branch created by adwPlan.tsx
+ * - Plan file must exist at specs/issue-{number}.md
+ *
+ * Environment Requirements:
+ * - ANTHROPIC_API_KEY: Anthropic API key
+ * - CLAUDE_CODE_PATH: Path to Claude CLI (default: /usr/local/bin/claude)
+ * - GITHUB_PAT: (Optional) GitHub Personal Access Token
+ */
+
+import * as fs from 'fs';
+import { execSync } from 'child_process';
+import {
+  log,
+  generateAdwId,
+  ensureLogsDirectory,
+  IssueClassSlashCommand,
+  WorkflowStage,
+  RecoveryState,
+  commitPrefixMap,
+  AgentStateManager,
+  AgentState,
+} from './core';
+import {
+  fetchGitHubIssue,
+  commitChanges,
+  createPullRequest,
+  postWorkflowComment,
+  WorkflowContext,
+  detectRecoveryState,
+  STAGE_ORDER,
+  getCurrentBranch,
+  inferIssueTypeFromBranch,
+} from './github';
+import {
+  runBuildAgent,
+  getPlanFilePath,
+  planFileExists,
+  ProgressCallback,
+  ProgressInfo,
+} from './agents';
+
+/**
+ * Determines if a stage should be executed based on recovery state.
+ */
+function shouldExecuteStage(stage: WorkflowStage, recoveryState: RecoveryState): boolean {
+  if (!recoveryState.canResume || !recoveryState.lastCompletedStage) {
+    return true;
+  }
+
+  const stageIndex = STAGE_ORDER.indexOf(stage);
+  const lastCompletedIndex = STAGE_ORDER.indexOf(recoveryState.lastCompletedStage);
+
+  return stageIndex > lastCompletedIndex;
+}
+
+/**
+ * Checks if there are uncommitted changes in the working directory.
+ */
+function hasUncommittedChanges(): boolean {
+  try {
+    const status = execSync('git status --porcelain', { encoding: 'utf-8' });
+    return status.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Gets the next stage to resume from based on the last completed stage.
+ */
+function getNextStage(lastCompletedStage: WorkflowStage): WorkflowStage {
+  const index = STAGE_ORDER.indexOf(lastCompletedStage);
+  if (index === -1 || index >= STAGE_ORDER.length - 1) {
+    return 'starting';
+  }
+  return STAGE_ORDER[index + 1];
+}
+
+/**
+ * Prints usage information and exits.
+ */
+function printUsageAndExit(): never {
+  console.error('Usage: npx tsx adws/adwBuild.tsx <github-issue-number> [adw-id]');
+  console.error('');
+  console.error('Prerequisites:');
+  console.error('  - Must be on a feature/bugfix/chore branch');
+  console.error('  - Plan file must exist at specs/issue-{number}.md');
+  console.error('');
+  console.error('Environment Requirements:');
+  console.error('  ANTHROPIC_API_KEY  - Anthropic API key');
+  console.error('  CLAUDE_CODE_PATH   - Path to Claude CLI (default: /usr/local/bin/claude)');
+  console.error('  GITHUB_PAT         - (Optional) GitHub Personal Access Token');
+  process.exit(1);
+}
+
+/**
+ * Parses and validates command line arguments.
+ */
+function parseArguments(args: string[]): { issueNumber: number; providedAdwId: string | null } {
+  if (args.length < 1) {
+    printUsageAndExit();
+  }
+
+  const issueNumber = parseInt(args[0], 10);
+  if (isNaN(issueNumber)) {
+    console.error(`Invalid issue number: ${args[0]}`);
+    process.exit(1);
+  }
+
+  const providedAdwId = args[1] || null;
+
+  return { issueNumber, providedAdwId };
+}
+
+/**
+ * Prints the build phase summary.
+ */
+function printBuildSummary(
+  issueNumber: number,
+  issueTitle: string,
+  branchName: string,
+  logsDir: string,
+  prUrl: string,
+  costUsd: number
+): void {
+  log('===================================', 'info');
+  log('ADW Build workflow completed!', 'success');
+  log(`Issue: #${issueNumber} - ${issueTitle}`, 'info');
+  log(`Branch: ${branchName}`, 'info');
+
+  if (prUrl) {
+    log(`PR: ${prUrl}`, 'info');
+  }
+
+  log(`Logs: ${logsDir}`, 'info');
+
+  if (costUsd > 0) {
+    log(`Cost: $${costUsd.toFixed(4)}`, 'info');
+  }
+
+  log('===================================', 'info');
+}
+
+/**
+ * Main build workflow.
+ */
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const { issueNumber, providedAdwId } = parseArguments(args);
+
+  log(`Starting ADW Build workflow`, 'info');
+  log(`Issue: #${issueNumber}`, 'info');
+
+  // Step 1: Fetch GitHub issue
+  log('Fetching GitHub issue...', 'info');
+  const issue = await fetchGitHubIssue(issueNumber);
+  log(`Fetched issue: ${issue.title}`, 'success');
+
+  // Step 2: Determine ADW ID
+  const adwId = providedAdwId || generateAdwId();
+  const logsDir = ensureLogsDirectory(adwId);
+  log(`ADW ID: ${adwId}`, 'info');
+  log(`Logs: ${logsDir}`, 'info');
+
+  // Step 3: Verify current branch and plan file
+  const branchName = getCurrentBranch();
+  log(`Current branch: ${branchName}`, 'info');
+
+  const planPath = getPlanFilePath(issueNumber);
+  if (!planFileExists(issueNumber)) {
+    log(`Plan file not found: ${planPath}`, 'error');
+    log('Run adwPlan.tsx first to generate the plan.', 'error');
+    process.exit(1);
+  }
+
+  // Read plan content
+  let planContent: string;
+  try {
+    planContent = fs.readFileSync(planPath, 'utf-8');
+    log(`Plan loaded from: ${planPath}`, 'success');
+  } catch (error) {
+    log(`Cannot read plan file at ${planPath}: ${error}`, 'error');
+    process.exit(1);
+  }
+
+  // Step 4: Infer issue type from branch name
+  const issueType: IssueClassSlashCommand = inferIssueTypeFromBranch(branchName);
+  log(`Issue type (from branch): ${issueType}`, 'info');
+
+  // Initialize orchestrator state
+  const orchestratorStatePath = AgentStateManager.initializeState(adwId, 'build-orchestrator');
+  log(`State: ${orchestratorStatePath}`, 'info');
+
+  const initialState: Partial<AgentState> = {
+    adwId,
+    issueNumber,
+    branchName,
+    issueClass: issueType,
+    planFile: planPath,
+    agentName: 'build-orchestrator',
+    execution: AgentStateManager.createExecutionState('running'),
+  };
+  AgentStateManager.writeState(orchestratorStatePath, initialState);
+  AgentStateManager.appendLog(orchestratorStatePath, `Starting ADW Build workflow for issue #${issueNumber}`);
+
+  // Detect recovery state from existing comments
+  const recoveryState = detectRecoveryState(issue.comments);
+
+  // Initialize workflow context
+  const ctx: WorkflowContext = {
+    issueNumber,
+    adwId,
+    branchName,
+    planPath,
+    issueType,
+  };
+
+  // Handle recovery mode
+  if (recoveryState.canResume && recoveryState.lastCompletedStage) {
+    log(`Recovery mode active: last completed stage was '${recoveryState.lastCompletedStage}'`, 'info');
+
+    if (hasUncommittedChanges()) {
+      log('Warning: There are uncommitted changes in the working directory', 'info');
+    }
+
+    if (recoveryState.prUrl) ctx.prUrl = recoveryState.prUrl;
+
+    const nextStage = getNextStage(recoveryState.lastCompletedStage);
+    ctx.resumeFrom = nextStage;
+    postWorkflowComment(issueNumber, 'resuming', ctx);
+  }
+
+  try {
+    let buildCostUsd = 0;
+
+    // Step 5: Run Build Agent
+    if (shouldExecuteStage('implemented', recoveryState)) {
+      postWorkflowComment(issueNumber, 'implementing', ctx);
+      log('Running Build Agent...', 'info');
+
+      const buildAgentStatePath = AgentStateManager.initializeState(adwId, 'build-agent', orchestratorStatePath);
+      AgentStateManager.writeState(buildAgentStatePath, {
+        adwId,
+        issueNumber,
+        branchName,
+        planFile: planPath,
+        issueClass: issueType,
+        agentName: 'build-agent',
+        parentAgent: 'build-orchestrator',
+        execution: AgentStateManager.createExecutionState('running'),
+      });
+
+      // Track progress and post periodic updates
+      let lastProgressUpdate = Date.now();
+      const PROGRESS_UPDATE_INTERVAL_MS = 60000;
+
+      const buildProgressCallback: ProgressCallback = (info: ProgressInfo) => {
+        ctx.buildProgress = {
+          turnCount: info.turnCount || 0,
+          toolCount: info.toolCount || 0,
+          lastToolName: info.toolName,
+          lastText: info.text,
+        };
+
+        if (info.type === 'tool_use') {
+          log(`  [Turn ${info.turnCount}] Tool: ${info.toolName}`, 'info');
+        }
+
+        const now = Date.now();
+        if (now - lastProgressUpdate >= PROGRESS_UPDATE_INTERVAL_MS) {
+          postWorkflowComment(issueNumber, 'build_progress', ctx);
+          lastProgressUpdate = now;
+        }
+      };
+
+      const buildResult = await runBuildAgent(issue, logsDir, planContent, buildProgressCallback, buildAgentStatePath);
+
+      if (!buildResult.success) {
+        AgentStateManager.writeState(buildAgentStatePath, {
+          execution: AgentStateManager.completeExecution(
+            AgentStateManager.createExecutionState('running'),
+            false,
+            buildResult.output
+          ),
+        });
+        throw new Error(`Build Agent failed: ${buildResult.output}`);
+      }
+
+      AgentStateManager.writeState(buildAgentStatePath, {
+        output: buildResult.output.substring(0, 1000),
+        execution: AgentStateManager.completeExecution(
+          AgentStateManager.createExecutionState('running'),
+          true
+        ),
+      });
+
+      AgentStateManager.appendLog(orchestratorStatePath, 'Build completed');
+
+      ctx.buildOutput = buildResult.output;
+      buildCostUsd = buildResult.totalCostUsd || 0;
+      postWorkflowComment(issueNumber, 'implemented', ctx);
+    } else {
+      log('Skipping Build Agent (already completed)', 'info');
+    }
+
+    // Step 6: Commit implementation
+    if (shouldExecuteStage('implementation_committing', recoveryState)) {
+      postWorkflowComment(issueNumber, 'implementation_committing', ctx);
+      commitChanges(`${commitPrefixMap[issueType]} implement #${issueNumber} - ${issue.title}`);
+    } else {
+      log('Skipping implementation commit (already completed)', 'info');
+    }
+
+    // Step 7: Create PR
+    if (shouldExecuteStage('pr_created', recoveryState) && !ctx.prUrl) {
+      postWorkflowComment(issueNumber, 'pr_creating', ctx);
+      log('Creating Pull Request...', 'info');
+      const prUrl = createPullRequest(issue, ctx.planOutput || '', ctx.buildOutput || '');
+      ctx.prUrl = prUrl;
+      postWorkflowComment(issueNumber, 'pr_created', ctx);
+    } else {
+      log('Skipping PR creation (already created)', 'info');
+    }
+
+    // Workflow completed
+    postWorkflowComment(issueNumber, 'completed', ctx);
+
+    // Update final orchestrator state
+    AgentStateManager.writeState(orchestratorStatePath, {
+      execution: AgentStateManager.completeExecution(
+        AgentStateManager.createExecutionState('running'),
+        true
+      ),
+      metadata: {
+        prUrl: ctx.prUrl,
+        totalCostUsd: buildCostUsd,
+      },
+    });
+    AgentStateManager.appendLog(orchestratorStatePath, 'Build workflow completed successfully');
+
+    // Print summary
+    printBuildSummary(
+      issueNumber,
+      issue.title,
+      branchName,
+      logsDir,
+      ctx.prUrl || '',
+      buildCostUsd
+    );
+
+  } catch (error) {
+    ctx.errorMessage = String(error);
+    postWorkflowComment(issueNumber, 'error', ctx);
+
+    AgentStateManager.writeState(orchestratorStatePath, {
+      execution: AgentStateManager.completeExecution(
+        AgentStateManager.createExecutionState('running'),
+        false,
+        String(error)
+      ),
+    });
+    AgentStateManager.appendLog(orchestratorStatePath, `Build workflow failed: ${error}`);
+
+    log(`Build workflow failed: ${error}`, 'error');
+    process.exit(1);
+  }
+}
+
+main();

--- a/adws/adwPlan.tsx
+++ b/adws/adwPlan.tsx
@@ -1,0 +1,431 @@
+#!/usr/bin/env npx tsx
+/**
+ * ADW Plan - AI Developer Workflow Planning Phase
+ *
+ * Usage: npx tsx adws/adwPlan.tsx <github-issue-number> [adw-id]
+ *
+ * Workflow:
+ * 1. Fetch GitHub issue details
+ * 2. Checkout default branch and pull latest changes
+ * 3. Detect recovery state from existing comments
+ * 4. Classify issue type (feature, bug, chore, pr_review)
+ * 5. Create feature branch: {type}/issue-{number}-{slug}
+ * 6. Run Plan Agent: Generate implementation plan
+ * 7. Commit the plan
+ *
+ * Environment Requirements:
+ * - ANTHROPIC_API_KEY: Anthropic API key
+ * - CLAUDE_CODE_PATH: Path to Claude CLI (default: /usr/local/bin/claude)
+ * - GITHUB_PAT: (Optional) GitHub Personal Access Token
+ */
+
+import * as path from 'path';
+import { execSync } from 'child_process';
+import {
+  log,
+  generateAdwId,
+  ensureLogsDirectory,
+  GitHubIssue,
+  IssueClassSlashCommand,
+  WorkflowStage,
+  RecoveryState,
+  commitPrefixMap,
+  AgentStateManager,
+  AgentState,
+} from './core';
+import {
+  fetchGitHubIssue,
+  createFeatureBranch,
+  commitChanges,
+  postWorkflowComment,
+  WorkflowContext,
+  detectRecoveryState,
+  STAGE_ORDER,
+  checkoutDefaultBranch,
+} from './github';
+import {
+  runPlanAgent,
+  getPlanFilePath,
+  planFileExists,
+  runClaudeAgentWithCommand,
+} from './agents';
+
+/**
+ * Classifies a GitHub issue as feature, bug, or chore using the haiku model.
+ * Uses the /classify_issue slash command from .claude/commands/classify_issue.md
+ */
+async function classifyIssue(
+  issue: GitHubIssue,
+  logsDir: string,
+  statePath?: string
+): Promise<IssueClassSlashCommand> {
+  const labelsText = issue.labels.map(l => l.name).join(', ') || 'none';
+
+  const args = `**Title:** ${issue.title}
+**Labels:** ${labelsText}
+
+${issue.body || 'No description provided.'}`;
+
+  const outputFile = path.join(logsDir, 'classifier-agent.jsonl');
+  const result = await runClaudeAgentWithCommand(
+    '/classify_issue',
+    args,
+    'Classifier',
+    outputFile,
+    'haiku',
+    undefined,
+    statePath
+  );
+
+  if (!result.success) {
+    log('Classification failed, defaulting to /feature', 'info');
+    return '/feature';
+  }
+
+  const output = result.output.trim();
+  const validCommands: IssueClassSlashCommand[] = ['/feature', '/bug', '/chore', '/pr_review'];
+
+  for (const cmd of validCommands) {
+    if (output.includes(cmd)) {
+      return cmd;
+    }
+  }
+
+  if (output === '0') {
+    log('Issue classified as unknown type, defaulting to /feature', 'info');
+    return '/feature';
+  }
+
+  log('Could not parse classification result, defaulting to /feature', 'info');
+  return '/feature';
+}
+
+/**
+ * Determines if a stage should be executed based on recovery state.
+ */
+function shouldExecuteStage(stage: WorkflowStage, recoveryState: RecoveryState): boolean {
+  if (!recoveryState.canResume || !recoveryState.lastCompletedStage) {
+    return true;
+  }
+
+  const stageIndex = STAGE_ORDER.indexOf(stage);
+  const lastCompletedIndex = STAGE_ORDER.indexOf(recoveryState.lastCompletedStage);
+
+  return stageIndex > lastCompletedIndex;
+}
+
+/**
+ * Checks if there are uncommitted changes in the working directory.
+ */
+function hasUncommittedChanges(): boolean {
+  try {
+    const status = execSync('git status --porcelain', { encoding: 'utf-8' });
+    return status.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Gets the next stage to resume from based on the last completed stage.
+ */
+function getNextStage(lastCompletedStage: WorkflowStage): WorkflowStage {
+  const index = STAGE_ORDER.indexOf(lastCompletedStage);
+  if (index === -1 || index >= STAGE_ORDER.length - 1) {
+    return 'starting';
+  }
+  return STAGE_ORDER[index + 1];
+}
+
+/**
+ * Prints usage information and exits.
+ */
+function printUsageAndExit(): never {
+  console.error('Usage: npx tsx adws/adwPlan.tsx <github-issue-number> [adw-id]');
+  console.error('');
+  console.error('Environment Requirements:');
+  console.error('  ANTHROPIC_API_KEY  - Anthropic API key');
+  console.error('  CLAUDE_CODE_PATH   - Path to Claude CLI (default: /usr/local/bin/claude)');
+  console.error('  GITHUB_PAT         - (Optional) GitHub Personal Access Token');
+  process.exit(1);
+}
+
+/**
+ * Parses and validates command line arguments.
+ */
+function parseArguments(args: string[]): { issueNumber: number; providedAdwId: string | null } {
+  if (args.length < 1) {
+    printUsageAndExit();
+  }
+
+  const issueNumber = parseInt(args[0], 10);
+  if (isNaN(issueNumber)) {
+    console.error(`Invalid issue number: ${args[0]}`);
+    process.exit(1);
+  }
+
+  const providedAdwId = args[1] || null;
+
+  return { issueNumber, providedAdwId };
+}
+
+/**
+ * Prints the planning phase summary.
+ */
+function printPlanSummary(
+  issueNumber: number,
+  issueTitle: string,
+  adwId: string,
+  branchName: string,
+  planPath: string,
+  logsDir: string,
+  costUsd: number
+): void {
+  log('===================================', 'info');
+  log('ADW Plan workflow completed!', 'success');
+  log(`Issue: #${issueNumber} - ${issueTitle}`, 'info');
+  log(`ADW ID: ${adwId}`, 'info');
+  log(`Branch: ${branchName}`, 'info');
+  log(`Plan: ${planPath}`, 'info');
+  log(`Logs: ${logsDir}`, 'info');
+
+  if (costUsd > 0) {
+    log(`Cost: $${costUsd.toFixed(4)}`, 'info');
+  }
+
+  log('===================================', 'info');
+}
+
+/**
+ * Main planning workflow.
+ */
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const { issueNumber, providedAdwId } = parseArguments(args);
+
+  log(`Starting ADW Plan workflow`, 'info');
+  log(`Issue: #${issueNumber}`, 'info');
+
+  // Step 1: Fetch GitHub issue
+  log('Fetching GitHub issue...', 'info');
+  const issue = await fetchGitHubIssue(issueNumber);
+  log(`Fetched issue: ${issue.title}`, 'success');
+
+  // Step 2: Checkout default branch and pull latest changes
+  checkoutDefaultBranch();
+
+  // Step 3: Detect recovery state from existing comments
+  const recoveryState = detectRecoveryState(issue.comments);
+
+  // Step 4: Determine ADW ID
+  let adwId: string;
+  if (providedAdwId) {
+    adwId = providedAdwId;
+  } else if (recoveryState.canResume && recoveryState.adwId) {
+    adwId = recoveryState.adwId;
+    log(`Recovery mode: using existing ADW ID: ${adwId}`, 'info');
+  } else {
+    adwId = generateAdwId();
+  }
+
+  const logsDir = ensureLogsDirectory(adwId);
+  log(`ADW ID: ${adwId}`, 'info');
+  log(`Logs: ${logsDir}`, 'info');
+
+  // Initialize orchestrator state
+  const orchestratorStatePath = AgentStateManager.initializeState(adwId, 'plan-orchestrator');
+  log(`State: ${orchestratorStatePath}`, 'info');
+
+  const initialState: Partial<AgentState> = {
+    adwId,
+    issueNumber,
+    agentName: 'plan-orchestrator',
+    execution: AgentStateManager.createExecutionState('running'),
+  };
+  AgentStateManager.writeState(orchestratorStatePath, initialState);
+  AgentStateManager.appendLog(orchestratorStatePath, `Starting ADW Plan workflow for issue #${issueNumber}`);
+
+  // Initialize workflow context
+  const ctx: WorkflowContext = {
+    issueNumber,
+    adwId,
+  };
+
+  // Handle recovery mode
+  if (recoveryState.canResume && recoveryState.lastCompletedStage) {
+    log(`Recovery mode active: last completed stage was '${recoveryState.lastCompletedStage}'`, 'info');
+
+    if (hasUncommittedChanges()) {
+      log('Warning: There are uncommitted changes in the working directory', 'info');
+    }
+
+    if (recoveryState.branchName) ctx.branchName = recoveryState.branchName;
+    if (recoveryState.planPath) ctx.planPath = recoveryState.planPath;
+
+    const nextStage = getNextStage(recoveryState.lastCompletedStage);
+    ctx.resumeFrom = nextStage;
+    postWorkflowComment(issueNumber, 'resuming', ctx);
+  } else {
+    postWorkflowComment(issueNumber, 'starting', ctx);
+  }
+
+  try {
+    let planCostUsd = 0;
+    let branchName = ctx.branchName || '';
+
+    // Step 5: Classify issue type
+    let issueType: IssueClassSlashCommand;
+    if (shouldExecuteStage('classified', recoveryState)) {
+      log('Classifying issue type...', 'info');
+      const classifierStatePath = AgentStateManager.initializeState(adwId, 'classifier', orchestratorStatePath);
+      AgentStateManager.writeState(classifierStatePath, {
+        adwId,
+        issueNumber,
+        agentName: 'classifier',
+        parentAgent: 'plan-orchestrator',
+        execution: AgentStateManager.createExecutionState('running'),
+      });
+
+      issueType = await classifyIssue(issue, logsDir, classifierStatePath);
+      log(`Issue classified as: ${issueType}`, 'success');
+      ctx.issueType = issueType;
+
+      AgentStateManager.writeState(classifierStatePath, {
+        issueClass: issueType,
+        output: issueType,
+        execution: AgentStateManager.completeExecution(
+          AgentStateManager.createExecutionState('running'),
+          true
+        ),
+      });
+
+      AgentStateManager.writeState(orchestratorStatePath, { issueClass: issueType });
+      AgentStateManager.appendLog(orchestratorStatePath, `Issue classified as: ${issueType}`);
+
+      postWorkflowComment(issueNumber, 'classified', ctx);
+    } else {
+      log('Skipping classification (already completed)', 'info');
+      issueType = '/feature';
+      ctx.issueType = issueType;
+    }
+
+    // Step 6: Create branch
+    if (shouldExecuteStage('branch_created', recoveryState)) {
+      log('Creating branch...', 'info');
+      branchName = createFeatureBranch(issueNumber, issue.title, issueType);
+      log(`On branch: ${branchName}`, 'success');
+      ctx.branchName = branchName;
+
+      AgentStateManager.writeState(orchestratorStatePath, { branchName });
+      AgentStateManager.appendLog(orchestratorStatePath, `Branch created: ${branchName}`);
+
+      postWorkflowComment(issueNumber, 'branch_created', ctx);
+    } else {
+      log('Skipping branch creation (already completed)', 'info');
+      if (recoveryState.branchName) {
+        branchName = createFeatureBranch(issueNumber, issue.title, issueType);
+        ctx.branchName = branchName;
+      }
+    }
+
+    // Step 7: Run Plan Agent
+    const planPath = getPlanFilePath(issueNumber);
+    ctx.planPath = planPath;
+
+    if (shouldExecuteStage('plan_created', recoveryState) && !planFileExists(issueNumber)) {
+      postWorkflowComment(issueNumber, 'plan_building', ctx);
+      log('Running Plan Agent...', 'info');
+
+      const planAgentStatePath = AgentStateManager.initializeState(adwId, 'plan-agent', orchestratorStatePath);
+      AgentStateManager.writeState(planAgentStatePath, {
+        adwId,
+        issueNumber,
+        branchName,
+        issueClass: issueType,
+        agentName: 'plan-agent',
+        parentAgent: 'plan-orchestrator',
+        execution: AgentStateManager.createExecutionState('running'),
+      });
+
+      const planResult = await runPlanAgent(issue, logsDir, issueType, planAgentStatePath);
+
+      if (!planResult.success) {
+        AgentStateManager.writeState(planAgentStatePath, {
+          execution: AgentStateManager.completeExecution(
+            AgentStateManager.createExecutionState('running'),
+            false,
+            planResult.output
+          ),
+        });
+        throw new Error(`Plan Agent failed: ${planResult.output}`);
+      }
+
+      AgentStateManager.writeState(planAgentStatePath, {
+        planFile: planPath,
+        output: planResult.output.substring(0, 1000),
+        execution: AgentStateManager.completeExecution(
+          AgentStateManager.createExecutionState('running'),
+          true
+        ),
+      });
+
+      AgentStateManager.writeState(orchestratorStatePath, { planFile: planPath });
+      AgentStateManager.appendLog(orchestratorStatePath, `Plan created: ${planPath}`);
+
+      ctx.planOutput = planResult.output;
+      planCostUsd = planResult.totalCostUsd || 0;
+      postWorkflowComment(issueNumber, 'plan_created', ctx);
+    } else {
+      log('Skipping Plan Agent (plan already exists or completed)', 'info');
+    }
+
+    // Step 8: Commit plan
+    if (shouldExecuteStage('plan_committing', recoveryState)) {
+      postWorkflowComment(issueNumber, 'plan_committing', ctx);
+      commitChanges(`${commitPrefixMap[issueType]} add implementation plan for #${issueNumber}`);
+    } else {
+      log('Skipping plan commit (already completed)', 'info');
+    }
+
+    // Update final state
+    AgentStateManager.writeState(orchestratorStatePath, {
+      execution: AgentStateManager.completeExecution(
+        AgentStateManager.createExecutionState('running'),
+        true
+      ),
+      metadata: {
+        totalCostUsd: planCostUsd,
+      },
+    });
+    AgentStateManager.appendLog(orchestratorStatePath, 'Plan workflow completed successfully');
+
+    // Print summary
+    printPlanSummary(
+      issueNumber,
+      issue.title,
+      adwId,
+      branchName,
+      planPath,
+      logsDir,
+      planCostUsd
+    );
+
+  } catch (error) {
+    ctx.errorMessage = String(error);
+    postWorkflowComment(issueNumber, 'error', ctx);
+
+    AgentStateManager.writeState(orchestratorStatePath, {
+      execution: AgentStateManager.completeExecution(
+        AgentStateManager.createExecutionState('running'),
+        false,
+        String(error)
+      ),
+    });
+    AgentStateManager.appendLog(orchestratorStatePath, `Plan workflow failed: ${error}`);
+
+    log(`Plan workflow failed: ${error}`, 'error');
+    process.exit(1);
+  }
+}
+
+main();

--- a/adws/adwPlanBuild.tsx
+++ b/adws/adwPlanBuild.tsx
@@ -1,15 +1,12 @@
 #!/usr/bin/env npx tsx
 /**
- * ADW Plan & Build - AI Developer Workflow
+ * ADW Plan & Build - AI Developer Workflow Orchestrator
+ *
+ * This script orchestrates the complete ADW workflow by calling:
+ * 1. adwPlan.tsx - Planning phase (classification, branch creation, plan generation)
+ * 2. adwBuild.tsx - Build phase (implementation, commit, PR creation)
  *
  * Usage: npx tsx adws/adwPlanBuild.tsx <github-issue-number> [adw-id]
- *
- * Workflow:
- * 1. Fetch GitHub issue details
- * 2. Create feature branch: feature/issue-{number}-{slug}
- * 3. Plan Agent: Generate implementation plan
- * 4. Build Agent: Implement the solution
- * 5. Create PR with full context
  *
  * Environment Requirements:
  * - ANTHROPIC_API_KEY: Anthropic API key
@@ -17,171 +14,18 @@
  * - GITHUB_PAT: (Optional) GitHub Personal Access Token
  */
 
-import * as path from 'path';
-import * as fs from 'fs';
-import { execSync } from 'child_process';
-import {
-  log,
-  generateAdwId,
-  ensureLogsDirectory,
-  GitHubIssue,
-  IssueClassSlashCommand,
-  WorkflowStage,
-  RecoveryState,
-  commitPrefixMap,
-  AgentStateManager,
-  AgentState,
-} from './core';
-import {
-  fetchGitHubIssue,
-  createFeatureBranch,
-  commitChanges,
-  createPullRequest,
-  postWorkflowComment,
-  WorkflowContext,
-  detectRecoveryState,
-  STAGE_ORDER,
-  checkoutDefaultBranch,
-} from './github';
-import {
-  runPlanAgent,
-  getPlanFilePath,
-  planFileExists,
-  runBuildAgent,
-  runClaudeAgentWithCommand,
-  ProgressCallback,
-  ProgressInfo,
-} from './agents';
-
-/**
- * Classifies a GitHub issue as feature, bug, or chore using the haiku model.
- * Uses the /classify_issue slash command from .claude/commands/classify_issue.md
- */
-async function classifyIssue(
-  issue: GitHubIssue,
-  logsDir: string,
-  statePath?: string
-): Promise<IssueClassSlashCommand> {
-  const labelsText = issue.labels.map(l => l.name).join(', ') || 'none';
-
-  // Format the issue context as arguments for the /classify_issue command
-  // This matches the $ARGUMENTS placeholder in classify_issue.md
-  const args = `**Title:** ${issue.title}
-**Labels:** ${labelsText}
-
-${issue.body || 'No description provided.'}`;
-
-  const outputFile = path.join(logsDir, 'classifier-agent.jsonl');
-  const result = await runClaudeAgentWithCommand(
-    '/classify_issue',
-    args,
-    'Classifier',
-    outputFile,
-    'haiku',
-    undefined,
-    statePath
-  );
-
-  if (!result.success) {
-    log('Classification failed, defaulting to /feature', 'info');
-    return '/feature';
-  }
-
-  const output = result.output.trim();
-  const validCommands: IssueClassSlashCommand[] = ['/feature', '/bug', '/chore', '/pr_review'];
-
-  for (const cmd of validCommands) {
-    if (output.includes(cmd)) {
-      return cmd;
-    }
-  }
-
-  if (output === '0') {
-    log('Issue classified as unknown type, defaulting to /feature', 'info');
-    return '/feature';
-  }
-
-  log('Could not parse classification result, defaulting to /feature', 'info');
-  return '/feature';
-}
-
-// commitPrefixMap is now imported from ./core
-
-/**
- * Determines if a stage should be executed based on recovery state.
- * Returns false if the stage has already been completed in a previous run.
- */
-function shouldExecuteStage(stage: WorkflowStage, recoveryState: RecoveryState): boolean {
-  if (!recoveryState.canResume || !recoveryState.lastCompletedStage) {
-    return true;
-  }
-
-  const stageIndex = STAGE_ORDER.indexOf(stage);
-  const lastCompletedIndex = STAGE_ORDER.indexOf(recoveryState.lastCompletedStage);
-
-  return stageIndex > lastCompletedIndex;
-}
-
-/**
- * Checks if there are uncommitted changes in the working directory.
- */
-function hasUncommittedChanges(): boolean {
-  try {
-    const status = execSync('git status --porcelain', { encoding: 'utf-8' });
-    return status.trim().length > 0;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Gets the next stage to resume from based on the last completed stage.
- */
-function getNextStage(lastCompletedStage: WorkflowStage): WorkflowStage {
-  const index = STAGE_ORDER.indexOf(lastCompletedStage);
-  if (index === -1 || index >= STAGE_ORDER.length - 1) {
-    return 'starting';
-  }
-  return STAGE_ORDER[index + 1];
-}
-
-/**
- * Prints the final workflow summary.
- */
-function printWorkflowSummary(
-  issueNumber: number,
-  issueTitle: string,
-  branchName: string,
-  logsDir: string,
-  prUrl: string,
-  planCostUsd: number,
-  buildCostUsd: number
-): void {
-  log('===================================', 'info');
-  log('ADW Plan & Build workflow completed!', 'success');
-  log(`Issue: #${issueNumber} - ${issueTitle}`, 'info');
-  log(`Branch: ${branchName}`, 'info');
-  log(`Plan: ${getPlanFilePath(issueNumber)}`, 'info');
-
-  if (prUrl) {
-    log(`PR: ${prUrl}`, 'info');
-  }
-
-  log(`Logs: ${logsDir}`, 'info');
-
-  const totalCost = planCostUsd + buildCostUsd;
-  if (totalCost > 0) {
-    log(`Total cost: $${totalCost.toFixed(4)}`, 'info');
-  }
-
-  log('===================================', 'info');
-}
+import { execSync, SpawnSyncReturns } from 'child_process';
+import { log, generateAdwId } from './core';
 
 /**
  * Prints usage information and exits.
  */
 function printUsageAndExit(): never {
   console.error('Usage: npx tsx adws/adwPlanBuild.tsx <github-issue-number> [adw-id]');
+  console.error('');
+  console.error('This orchestrator runs the complete ADW workflow:');
+  console.error('  1. adwPlan.tsx  - Plan generation');
+  console.error('  2. adwBuild.tsx - Implementation and PR creation');
   console.error('');
   console.error('Environment Requirements:');
   console.error('  ANTHROPIC_API_KEY  - Anthropic API key');
@@ -192,9 +36,8 @@ function printUsageAndExit(): never {
 
 /**
  * Parses and validates command line arguments.
- * Returns the adwId as null if not provided (will be determined during recovery detection).
  */
-function parseArguments(args: string[]): { issueNumber: number; providedAdwId: string | null } {
+function parseArguments(args: string[]): { issueNumber: number; adwId: string } {
   if (args.length < 1) {
     printUsageAndExit();
   }
@@ -205,366 +48,58 @@ function parseArguments(args: string[]): { issueNumber: number; providedAdwId: s
     process.exit(1);
   }
 
-  const providedAdwId = args[1] || null;
+  const adwId = args[1] || generateAdwId();
 
-  return { issueNumber, providedAdwId };
+  return { issueNumber, adwId };
 }
 
 /**
- * Main workflow orchestrator.
+ * Executes a subprocess and returns success status.
  */
-async function main(): Promise<void> {
-  const args = process.argv.slice(2);
-  const { issueNumber, providedAdwId } = parseArguments(args);
-
-  log(`Starting ADW Plan & Build workflow`, 'info');
-  log(`Issue: #${issueNumber}`, 'info');
-
-  // Step 1: Fetch GitHub issue first to detect recovery state
-  log('Fetching GitHub issue...', 'info');
-  const issue = await fetchGitHubIssue(issueNumber);
-  log(`Fetched issue: ${issue.title}`, 'success');
-
-  // Step 1.5: Checkout default branch and pull latest changes
-  // This ensures feature branches are created from the latest code
-  const defaultBranch = checkoutDefaultBranch();
-
-  // Detect recovery state from existing comments
-  const recoveryState = detectRecoveryState(issue.comments);
-
-  // Determine ADW ID - use provided, or recovered, or generate new
-  let adwId: string;
-  if (providedAdwId) {
-    adwId = providedAdwId;
-  } else if (recoveryState.canResume && recoveryState.adwId) {
-    adwId = recoveryState.adwId;
-    log(`Recovery mode: using existing ADW ID: ${adwId}`, 'info');
-  } else {
-    adwId = generateAdwId();
-  }
-
-  const logsDir = ensureLogsDirectory(adwId);
-  log(`ADW ID: ${adwId}`, 'info');
-  log(`Logs: ${logsDir}`, 'info');
-
-  // Initialize orchestrator state directory
-  const orchestratorStatePath = AgentStateManager.initializeState(adwId, 'orchestrator');
-  log(`State: ${orchestratorStatePath}`, 'info');
-
-  // Write initial orchestrator state
-  const initialOrchestratorState: Partial<AgentState> = {
-    adwId,
-    issueNumber,
-    agentName: 'orchestrator',
-    execution: AgentStateManager.createExecutionState('running'),
-  };
-  AgentStateManager.writeState(orchestratorStatePath, initialOrchestratorState);
-  AgentStateManager.appendLog(orchestratorStatePath, `Starting ADW Plan & Build workflow for issue #${issueNumber}`);
-
-  // Initialize workflow context
-  const ctx: WorkflowContext = {
-    issueNumber,
-    adwId,
-  };
-
-  // Check for recovery mode
-  if (recoveryState.canResume && recoveryState.lastCompletedStage) {
-    log(`Recovery mode active: last completed stage was '${recoveryState.lastCompletedStage}'`, 'info');
-
-    // Warn if there are uncommitted changes
-    if (hasUncommittedChanges()) {
-      log('Warning: There are uncommitted changes in the working directory', 'info');
-    }
-
-    // Pre-populate context from recovery state
-    if (recoveryState.branchName) ctx.branchName = recoveryState.branchName;
-    if (recoveryState.planPath) ctx.planPath = recoveryState.planPath;
-    if (recoveryState.prUrl) ctx.prUrl = recoveryState.prUrl;
-
-    // Post resuming comment
-    const nextStage = getNextStage(recoveryState.lastCompletedStage);
-    ctx.resumeFrom = nextStage;
-    postWorkflowComment(issueNumber, 'resuming', ctx);
-  } else {
-    // Post starting comment for new workflow
-    postWorkflowComment(issueNumber, 'starting', ctx);
-  }
+function runSubprocess(command: string, description: string): boolean {
+  log(`Starting: ${description}`, 'info');
 
   try {
-    // Track costs for agents that run
-    let planCostUsd = 0;
-    let buildCostUsd = 0;
-    let branchName = ctx.branchName || '';
-
-    // Step 1.5: Classify issue type
-    let issueType: IssueClassSlashCommand;
-    if (shouldExecuteStage('classified', recoveryState)) {
-      log('Classifying issue type...', 'info');
-      // Initialize classifier agent state
-      const classifierStatePath = AgentStateManager.initializeState(adwId, 'classifier', orchestratorStatePath);
-      AgentStateManager.writeState(classifierStatePath, {
-        adwId,
-        issueNumber,
-        agentName: 'classifier',
-        parentAgent: 'orchestrator',
-        execution: AgentStateManager.createExecutionState('running'),
-      });
-
-      issueType = await classifyIssue(issue, logsDir, classifierStatePath);
-      log(`Issue classified as: ${issueType}`, 'success');
-      ctx.issueType = issueType;
-
-      // Update classifier state with result
-      AgentStateManager.writeState(classifierStatePath, {
-        issueClass: issueType,
-        output: issueType,
-        execution: AgentStateManager.completeExecution(
-          AgentStateManager.createExecutionState('running'),
-          true
-        ),
-      });
-
-      // Update orchestrator state
-      AgentStateManager.writeState(orchestratorStatePath, { issueClass: issueType });
-      AgentStateManager.appendLog(orchestratorStatePath, `Issue classified as: ${issueType}`);
-
-      postWorkflowComment(issueNumber, 'classified', ctx);
-    } else {
-      log('Skipping classification (already completed)', 'info');
-      // Default to feature if we can't determine from recovery
-      issueType = '/feature';
-      ctx.issueType = issueType;
-    }
-
-    // Step 2: Create branch with appropriate prefix based on issue type
-    if (shouldExecuteStage('branch_created', recoveryState)) {
-      log('Creating branch...', 'info');
-      branchName = createFeatureBranch(issueNumber, issue.title, issueType);
-      log(`On branch: ${branchName}`, 'success');
-      ctx.branchName = branchName;
-
-      // Update orchestrator state with branch name
-      AgentStateManager.writeState(orchestratorStatePath, { branchName });
-      AgentStateManager.appendLog(orchestratorStatePath, `Branch created: ${branchName}`);
-
-      postWorkflowComment(issueNumber, 'branch_created', ctx);
-    } else {
-      log('Skipping branch creation (already completed)', 'info');
-      // If we have a branch from recovery state, check it out
-      if (recoveryState.branchName) {
-        branchName = createFeatureBranch(issueNumber, issue.title, issueType);
-        ctx.branchName = branchName;
-      }
-    }
-
-    // Step 3: Run Plan Agent
-    const planPath = getPlanFilePath(issueNumber);
-    ctx.planPath = planPath;
-
-    if (shouldExecuteStage('plan_created', recoveryState) && !planFileExists(issueNumber)) {
-      postWorkflowComment(issueNumber, 'plan_building', ctx);
-      log('Running Plan Agent...', 'info');
-
-      // Initialize plan agent state
-      const planAgentStatePath = AgentStateManager.initializeState(adwId, 'plan-agent', orchestratorStatePath);
-      AgentStateManager.writeState(planAgentStatePath, {
-        adwId,
-        issueNumber,
-        branchName,
-        issueClass: issueType,
-        agentName: 'plan-agent',
-        parentAgent: 'orchestrator',
-        execution: AgentStateManager.createExecutionState('running'),
-      });
-
-      const planResult = await runPlanAgent(issue, logsDir, issueType, planAgentStatePath);
-
-      if (!planResult.success) {
-        AgentStateManager.writeState(planAgentStatePath, {
-          execution: AgentStateManager.completeExecution(
-            AgentStateManager.createExecutionState('running'),
-            false,
-            planResult.output
-          ),
-        });
-        throw new Error(`Plan Agent failed: ${planResult.output}`);
-      }
-
-      // Update plan agent state with result
-      AgentStateManager.writeState(planAgentStatePath, {
-        planFile: planPath,
-        output: planResult.output.substring(0, 1000), // Truncate for state
-        execution: AgentStateManager.completeExecution(
-          AgentStateManager.createExecutionState('running'),
-          true
-        ),
-      });
-
-      // Update orchestrator state
-      AgentStateManager.writeState(orchestratorStatePath, { planFile: planPath });
-      AgentStateManager.appendLog(orchestratorStatePath, `Plan created: ${planPath}`);
-
-      ctx.planOutput = planResult.output;
-      planCostUsd = planResult.totalCostUsd || 0;
-      postWorkflowComment(issueNumber, 'plan_created', ctx);
-    } else {
-      log('Skipping Plan Agent (plan already exists or completed)', 'info');
-    }
-
-    // Commit plan (only if there are changes)
-    if (shouldExecuteStage('plan_committing', recoveryState)) {
-      postWorkflowComment(issueNumber, 'plan_committing', ctx);
-      commitChanges(`${commitPrefixMap[issueType]} add implementation plan for #${issueNumber}`);
-    } else {
-      log('Skipping plan commit (already completed)', 'info');
-    }
-
-    // Step 4: Run Build Agent
-    if (shouldExecuteStage('implemented', recoveryState)) {
-      postWorkflowComment(issueNumber, 'implementing', ctx);
-      log('Running Build Agent...', 'info');
-
-      // Read plan content to pass to Build Agent
-      let planContent: string;
-      try {
-        planContent = fs.readFileSync(planPath, 'utf-8');
-      } catch (error) {
-        throw new Error(`Cannot read plan file at ${planPath}: ${error}`);
-      }
-
-      // Initialize build agent state
-      const buildAgentStatePath = AgentStateManager.initializeState(adwId, 'build-agent', orchestratorStatePath);
-      AgentStateManager.writeState(buildAgentStatePath, {
-        adwId,
-        issueNumber,
-        branchName,
-        planFile: planPath,
-        issueClass: issueType,
-        agentName: 'build-agent',
-        parentAgent: 'orchestrator',
-        execution: AgentStateManager.createExecutionState('running'),
-      });
-
-      // Track progress and post periodic updates
-      let lastProgressUpdate = Date.now();
-      const PROGRESS_UPDATE_INTERVAL_MS = 60000; // Post progress every 60 seconds
-
-      const buildProgressCallback: ProgressCallback = (info: ProgressInfo) => {
-        // Update context with latest progress info
-        ctx.buildProgress = {
-          turnCount: info.turnCount || 0,
-          toolCount: info.toolCount || 0,
-          lastToolName: info.toolName,
-          lastText: info.text,
-        };
-
-        // Log progress locally
-        if (info.type === 'tool_use') {
-          log(`  [Turn ${info.turnCount}] Tool: ${info.toolName}`, 'info');
-        }
-
-        // Post progress update to GitHub if enough time has passed
-        const now = Date.now();
-        if (now - lastProgressUpdate >= PROGRESS_UPDATE_INTERVAL_MS) {
-          postWorkflowComment(issueNumber, 'build_progress', ctx);
-          lastProgressUpdate = now;
-        }
-      };
-
-      const buildResult = await runBuildAgent(issue, logsDir, planContent, buildProgressCallback, buildAgentStatePath);
-
-      if (!buildResult.success) {
-        AgentStateManager.writeState(buildAgentStatePath, {
-          execution: AgentStateManager.completeExecution(
-            AgentStateManager.createExecutionState('running'),
-            false,
-            buildResult.output
-          ),
-        });
-        throw new Error(`Build Agent failed: ${buildResult.output}`);
-      }
-
-      // Update build agent state with result
-      AgentStateManager.writeState(buildAgentStatePath, {
-        output: buildResult.output.substring(0, 1000), // Truncate for state
-        execution: AgentStateManager.completeExecution(
-          AgentStateManager.createExecutionState('running'),
-          true
-        ),
-      });
-
-      AgentStateManager.appendLog(orchestratorStatePath, 'Build completed');
-
-      ctx.buildOutput = buildResult.output;
-      buildCostUsd = buildResult.totalCostUsd || 0;
-      postWorkflowComment(issueNumber, 'implemented', ctx);
-    } else {
-      log('Skipping Build Agent (already completed)', 'info');
-    }
-
-    // Commit implementation (only if there are changes)
-    if (shouldExecuteStage('implementation_committing', recoveryState)) {
-      postWorkflowComment(issueNumber, 'implementation_committing', ctx);
-      commitChanges(`${commitPrefixMap[issueType]} implement #${issueNumber} - ${issue.title}`);
-    } else {
-      log('Skipping implementation commit (already completed)', 'info');
-    }
-
-    // Step 5: Create PR
-    if (shouldExecuteStage('pr_created', recoveryState) && !ctx.prUrl) {
-      postWorkflowComment(issueNumber, 'pr_creating', ctx);
-      log('Creating Pull Request...', 'info');
-      const prUrl = createPullRequest(issue, ctx.planOutput || '', ctx.buildOutput || '');
-      ctx.prUrl = prUrl;
-      postWorkflowComment(issueNumber, 'pr_created', ctx);
-    } else {
-      log('Skipping PR creation (already created)', 'info');
-    }
-
-    // Workflow completed
-    postWorkflowComment(issueNumber, 'completed', ctx);
-
-    // Update final orchestrator state
-    AgentStateManager.writeState(orchestratorStatePath, {
-      execution: AgentStateManager.completeExecution(
-        AgentStateManager.createExecutionState('running'),
-        true
-      ),
-      metadata: {
-        prUrl: ctx.prUrl,
-        totalCostUsd: planCostUsd + buildCostUsd,
-      },
-    });
-    AgentStateManager.appendLog(orchestratorStatePath, 'Workflow completed successfully');
-
-    // Final summary
-    printWorkflowSummary(
-      issueNumber,
-      issue.title,
-      branchName,
-      logsDir,
-      ctx.prUrl || '',
-      planCostUsd,
-      buildCostUsd
-    );
-
+    execSync(command, { stdio: 'inherit' });
+    log(`Completed: ${description}`, 'success');
+    return true;
   } catch (error) {
-    ctx.errorMessage = String(error);
-    postWorkflowComment(issueNumber, 'error', ctx);
+    const execError = error as SpawnSyncReturns<Buffer>;
+    log(`Failed: ${description} (exit code: ${execError.status})`, 'error');
+    return false;
+  }
+}
 
-    // Update orchestrator state with error
-    AgentStateManager.writeState(orchestratorStatePath, {
-      execution: AgentStateManager.completeExecution(
-        AgentStateManager.createExecutionState('running'),
-        false,
-        String(error)
-      ),
-    });
-    AgentStateManager.appendLog(orchestratorStatePath, `Workflow failed: ${error}`);
+/**
+ * Main orchestrator workflow.
+ */
+function main(): void {
+  const args = process.argv.slice(2);
+  const { issueNumber, adwId } = parseArguments(args);
 
-    log(`Workflow failed: ${error}`, 'error');
+  log('===================================', 'info');
+  log('ADW Plan & Build Orchestrator', 'info');
+  log(`Issue: #${issueNumber}`, 'info');
+  log(`ADW ID: ${adwId}`, 'info');
+  log('===================================', 'info');
+
+  // Phase 1: Run Plan
+  const planCommand = `npx tsx adws/adwPlan.tsx ${issueNumber} ${adwId}`;
+  if (!runSubprocess(planCommand, 'Plan Phase')) {
+    log('Plan phase failed. Aborting workflow.', 'error');
     process.exit(1);
   }
+
+  // Phase 2: Run Build
+  const buildCommand = `npx tsx adws/adwBuild.tsx ${issueNumber} ${adwId}`;
+  if (!runSubprocess(buildCommand, 'Build Phase')) {
+    log('Build phase failed.', 'error');
+    process.exit(1);
+  }
+
+  log('===================================', 'info');
+  log('ADW Plan & Build workflow completed!', 'success');
+  log('===================================', 'info');
 }
 
 main();

--- a/adws/core/dataTypes.ts
+++ b/adws/core/dataTypes.ts
@@ -295,6 +295,8 @@ export interface PullRequestWebhookPayload {
  */
 export type AgentIdentifier =
   | 'orchestrator'
+  | 'plan-orchestrator'
+  | 'build-orchestrator'
   | 'classifier'
   | 'plan-agent'
   | 'build-agent'

--- a/specs/issue-32-plan.md
+++ b/specs/issue-32-plan.md
@@ -1,0 +1,127 @@
+# Chore: Split adwPlanBuild into adwPlan and adwBuild
+
+## Chore Description
+Break up the existing `adwPlanBuild.tsx` script (571 lines) into two focused applications:
+- **adwPlan.tsx**: Handles issue classification, branch creation, and plan generation (the `/plan` workflow)
+- **adwBuild.tsx**: Handles implementation execution and PR creation (the `/implement` workflow)
+
+Then create a new `adwPlanBuild.tsx` orchestrator that calls these applications in sequence, maintaining the same end-to-end workflow but with cleaner separation of concerns.
+
+## Relevant Files
+Use these files to resolve the chore:
+
+- **`adws/adwPlanBuild.tsx`** - The current monolithic script to be refactored. Contains classification, branch creation, plan agent execution, build agent execution, commit logic, and PR creation.
+- **`adws/agents/index.ts`** - Exports agent runner functions (runPlanAgent, runBuildAgent, etc.) that will be used by the new scripts.
+- **`adws/agents/planAgent.ts`** - Contains `runPlanAgent()` which executes the appropriate planning slash command (/feature, /bug, /chore, /pr_review).
+- **`adws/agents/buildAgent.ts`** - Contains `runBuildAgent()` which executes the /implement slash command.
+- **`adws/core/index.ts`** - Exports core utilities (log, generateAdwId, ensureLogsDirectory, AgentStateManager, etc.).
+- **`adws/github/index.ts`** - Exports GitHub operations (fetchGitHubIssue, createFeatureBranch, commitChanges, createPullRequest, etc.).
+- **`guidelines/coding_guidelines.md`** - Coding standards to follow (modular design, file size limits, pure functions, etc.).
+
+### New Files
+- **`adws/adwPlan.tsx`** - New standalone script for the planning workflow
+- **`adws/adwBuild.tsx`** - New standalone script for the build/implementation workflow
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### Step 1: Create adwPlan.tsx - The Planning Application
+Create a new `adws/adwPlan.tsx` script that focuses solely on the planning phase:
+
+- Add shebang and JSDoc documentation header explaining usage
+- Accept command line arguments: `<github-issue-number> [adw-id]`
+- Import required modules from `./core`, `./github`, and `./agents`
+- Implement the following workflow stages:
+  1. Parse and validate arguments
+  2. Fetch the GitHub issue using `fetchGitHubIssue()`
+  3. Checkout the default branch and pull latest changes using `checkoutDefaultBranch()`
+  4. Detect recovery state from existing comments using `detectRecoveryState()`
+  5. Generate or reuse ADW ID using `generateAdwId()` or recovery state
+  6. Create logs directory using `ensureLogsDirectory()`
+  7. Initialize orchestrator state using `AgentStateManager`
+  8. Classify the issue type using the classifier agent (extract `classifyIssue()` function)
+  9. Create the feature branch using `createFeatureBranch()`
+  10. Run the Plan Agent using `runPlanAgent()`
+  11. Commit the plan using `commitChanges()`
+  12. Post workflow comments at each stage using `postWorkflowComment()`
+- Handle errors and post error comments
+- Print a summary on completion with ADW ID, branch name, and plan path
+- Exit with appropriate exit code (0 for success, 1 for failure)
+- Extract helper functions from current adwPlanBuild.tsx: `classifyIssue()`, `shouldExecuteStage()`, `hasUncommittedChanges()`, `getNextStage()`, `printUsageAndExit()`, `parseArguments()`
+
+### Step 2: Create adwBuild.tsx - The Build Application
+Create a new `adws/adwBuild.tsx` script that focuses solely on the implementation phase:
+
+- Add shebang and JSDoc documentation header explaining usage
+- Accept command line arguments: `<github-issue-number> [adw-id]`
+- Import required modules from `./core`, `./github`, and `./agents`
+- Implement the following workflow stages:
+  1. Parse and validate arguments
+  2. Fetch the GitHub issue using `fetchGitHubIssue()`
+  3. Generate or reuse ADW ID (from argument or generate new)
+  4. Create logs directory using `ensureLogsDirectory()`
+  5. Initialize orchestrator state using `AgentStateManager`
+  6. Verify plan file exists using `planFileExists()` and `getPlanFilePath()`
+  7. Read the plan content from the specs file
+  8. Infer issue type from the current branch using `inferIssueTypeFromBranch()`
+  9. Run the Build Agent using `runBuildAgent()` with progress callback
+  10. Commit the implementation using `commitChanges()`
+  11. Create the Pull Request using `createPullRequest()`
+  12. Post workflow comments at each stage using `postWorkflowComment()`
+- Handle errors and post error comments
+- Print a summary on completion with branch name, PR URL, and cost
+- Exit with appropriate exit code (0 for success, 1 for failure)
+- Include the `shouldExecuteStage()` and recovery state detection logic for resumable workflows
+
+### Step 3: Refactor adwPlanBuild.tsx as Orchestrator
+Replace the current `adwPlanBuild.tsx` with a new orchestrator that calls the two applications in sequence:
+
+- Add shebang and JSDoc documentation header explaining it orchestrates adwPlan and adwBuild
+- Accept command line arguments: `<github-issue-number> [adw-id]`
+- Import `execSync` from `child_process` for subprocess invocation
+- Implement the orchestration workflow:
+  1. Parse and validate arguments
+  2. Log the start of the combined workflow
+  3. Execute `npx tsx adws/adwPlan.tsx <issue-number> [adw-id]` using `execSync`
+     - Capture stdout/stderr
+     - Check exit code
+     - If plan fails, log error and exit with code 1
+  4. Execute `npx tsx adws/adwBuild.tsx <issue-number> [adw-id]` using `execSync`
+     - Pass the same adw-id to maintain correlation
+     - Capture stdout/stderr
+     - Check exit code
+     - If build fails, log error and exit with code 1
+  5. Print a final summary combining outputs from both stages
+- Keep the orchestrator simple and focused (under 100 lines)
+- Use `stdio: 'inherit'` to stream subprocess output to the terminal in real-time
+
+### Step 4: Update Exports if Needed
+Review `adws/index.ts` to ensure any shared types or functions used by both adwPlan and adwBuild are properly exported:
+
+- Verify core utilities are accessible
+- Verify agent functions are accessible
+- Verify GitHub operations are accessible
+- No changes may be needed if imports are done from submodules directly
+
+### Step 5: Run Validation Commands
+Execute the validation commands to verify the chore is complete with zero regressions:
+
+- Run `npm run lint` to check for code quality issues
+- Run `npm run build` to verify no build errors
+- Run `npm test` to run tests and validate zero regressions
+
+## Validation Commands
+Execute every command to validate the chore is complete with zero regressions.
+
+- `npm run lint` - Run linter to check for code quality issues
+- `npm run build` - Build the application to verify no build errors
+- `npm test` - Run tests to validate the chore is complete with zero regressions
+
+## Notes
+- The current `adwPlanBuild.tsx` is 571 lines, which exceeds the 150-line guideline. Splitting into focused scripts will improve maintainability.
+- Both new scripts (`adwPlan.tsx` and `adwBuild.tsx`) should be usable independently, allowing developers to run just the planning phase or just the build phase as needed.
+- The ADW ID should be passed between scripts to maintain correlation and enable recovery/resumption of partial workflows.
+- Workflow comments posted to GitHub issues should continue to work as before, tracking progress through both phases.
+- Recovery state detection allows resuming a failed workflow from where it left off - this functionality must be preserved in both scripts.
+- The `printWorkflowSummary()` function from the original can be adapted for each script's specific summary needs.
+- Consider extracting shared helper functions (like `shouldExecuteStage()`, `hasUncommittedChanges()`) into a shared module if code duplication becomes excessive, but for now keeping them in each file is acceptable for clarity.


### PR DESCRIPTION
## Summary
Implements #32 - Split adwPlanBuild

## Implementation Plan
## Summary

I've created a comprehensive plan to resolve GitHub Issue #32 (Split adwPlanBuild). Here's what was done:

- **Researched the codebase**: Read README.md, coding guidelines, and all relevant ADW scripts
- **Analyzed the existing adwPlanBuild.tsx**: Understood the 571-line monolithic script structure including classification, branch creation, plan agent, build agent, commits, and PR creation
- **Studied patterns**: Examined `adwPrReview.tsx`, `healthCheck.tsx`, and agent modules to understand existing conventions
- **Created the implementation plan**: Wrote a detailed step-by-step plan in the required format

**Plan location:** `specs/issue-32-plan.md`

**Key aspects of the plan:**
- **Step 1**: Create `adwPlan.tsx` - handles issue classification, branch creation, plan generation, and plan commit
- **Step 2**: Create `adwBuild.tsx` - handles reading the plan, running build agent, committing implementation, and creating PR
- **Step 3**: Refactor `adwPlanBuild.tsx` as a lightweight orchestrator that calls the two scripts in sequence
- **Step 4**: Verify exports are properly configured
- **Step 5**: Run validation commands (lint, build, test)

## Changes Made
## Summary

I've successfully split `adwPlanBuild.tsx` (571 lines) into two focused applications:

**Changes made:**

- **Created `adws/adwPlan.tsx`** (431 lines) - Standalone planning application that handles:
  - GitHub issue fetching and classification
  - Default branch checkout and pulling latest changes
  - Recovery state detection for resumable workflows
  - Feature branch creation with appropriate prefix
  - Plan Agent execution and plan file generation
  - Plan commit with proper commit prefix
  - Workflow comments at each stage

- **Created `adws/adwBuild.tsx`** (384 lines) - Standalone build application that handles:
  - Plan file verification before implementation
  - Issue type inference from current branch name
  - Build Agent execution with progress callbacks
  - Implementation commit
  - PR creation
  - Recovery state support for resumable workflows

- **Refactored `adws/adwPlanBuild.tsx`** (105 lines) - Simple orchestrator that:
  - Generates/reuses ADW ID for correlation between phases
  - Executes adwPlan.tsx then adwBuild.tsx in sequence
  - Streams subprocess output to terminal in real-time
  - Exits with appropriate codes on failure

- **Updated `adws/core/dataTypes.ts`** - Added `'plan-orchestrator'` and `'build-orchestrator'` to `AgentIdentifier` type for state management

**Validation results:**
- `npm run lint` - No ESLint warnings or errors
- `npm run build` - Build successful
- `npm test` - All 46 tests passed

**Git diff stats:**
```
 adws/adwPlanBuild.tsx  | 565 +++++--------------------------------------------
 adws/core/dataTypes.ts |   2 +
 adws/adwPlan.tsx       | 431 (new file)
 adws/adwBuild.tsx      | 384 (new file)
 4 files changed, ~870 insertions, 515 deletions
```

## Testing
- [ ] All validation commands from the plan pass
- [ ] No regressions introduced
- [ ] Code follows project conventions

---
Generated by ADW Plan & Build workflow
