### PR TITLE
feat: Create a new adw, adwTest (#36)

### DIFF
--- a/adws/__tests__/testAgent.test.ts
+++ b/adws/__tests__/testAgent.test.ts
@@ -1,0 +1,337 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Mock the child_process module
+vi.mock('child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+// Mock the config module
+vi.mock('../core/config', () => ({
+  CLAUDE_CODE_PATH: '/usr/local/bin/claude',
+  AGENTS_STATE_DIR: '/tmp/test-agents',
+}));
+
+// Import after mocks are set up
+import { spawn } from 'child_process';
+import {
+  discoverE2ETestFiles,
+  runTestAgent,
+  runE2ETestAgent,
+  runResolveTestAgent,
+  runResolveE2ETestAgent,
+  TestResult,
+  E2ETestResult,
+} from '../agents/testAgent';
+
+describe('testAgent', () => {
+  const testLogsDir = '/tmp/test-logs';
+  const e2eTestsDir = path.join(process.cwd(), 'e2e-tests');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Clean up test directories
+    if (fs.existsSync(testLogsDir)) {
+      fs.rmSync(testLogsDir, { recursive: true, force: true });
+    }
+    fs.mkdirSync(testLogsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    // Clean up test directories
+    if (fs.existsSync(testLogsDir)) {
+      fs.rmSync(testLogsDir, { recursive: true, force: true });
+    }
+    // Clean up mock e2e-tests directory if created
+    if (fs.existsSync(e2eTestsDir)) {
+      fs.rmSync(e2eTestsDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('discoverE2ETestFiles', () => {
+    it('returns empty array when e2e-tests directory does not exist', () => {
+      const result = discoverE2ETestFiles();
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when e2e-tests directory is empty', () => {
+      fs.mkdirSync(e2eTestsDir, { recursive: true });
+      const result = discoverE2ETestFiles();
+      expect(result).toEqual([]);
+    });
+
+    it('returns only markdown files from e2e-tests directory', () => {
+      fs.mkdirSync(e2eTestsDir, { recursive: true });
+      fs.writeFileSync(path.join(e2eTestsDir, 'test_login.md'), '# Login Test');
+      fs.writeFileSync(path.join(e2eTestsDir, 'test_signup.md'), '# Signup Test');
+      fs.writeFileSync(path.join(e2eTestsDir, 'README.txt'), 'Not a test file');
+
+      const result = discoverE2ETestFiles();
+
+      expect(result).toHaveLength(2);
+      expect(result).toContain(path.join(e2eTestsDir, 'test_login.md'));
+      expect(result).toContain(path.join(e2eTestsDir, 'test_signup.md'));
+    });
+
+    it('returns files in sorted order', () => {
+      fs.mkdirSync(e2eTestsDir, { recursive: true });
+      fs.writeFileSync(path.join(e2eTestsDir, 'z_test.md'), '# Z Test');
+      fs.writeFileSync(path.join(e2eTestsDir, 'a_test.md'), '# A Test');
+      fs.writeFileSync(path.join(e2eTestsDir, 'm_test.md'), '# M Test');
+
+      const result = discoverE2ETestFiles();
+
+      expect(result[0]).toContain('a_test.md');
+      expect(result[1]).toContain('m_test.md');
+      expect(result[2]).toContain('z_test.md');
+    });
+  });
+
+  describe('runTestAgent', () => {
+    it('uses sonnet model for test execution', async () => {
+      const mockSpawn = createMockSpawn({
+        result: JSON.stringify([
+          { test_name: 'linting', passed: true, execution_command: 'npm run lint', test_purpose: 'Check linting' }
+        ])
+      });
+      (spawn as unknown as ReturnType<typeof vi.fn>).mockImplementation(mockSpawn);
+
+      await runTestAgent(testLogsDir);
+
+      expect(spawn).toHaveBeenCalledWith(
+        '/usr/local/bin/claude',
+        expect.arrayContaining(['--model', 'sonnet']),
+        expect.any(Object)
+      );
+    });
+
+    it('parses test results from JSON output', async () => {
+      const testResults: TestResult[] = [
+        { test_name: 'linting', passed: true, execution_command: 'npm run lint', test_purpose: 'Check linting' },
+        { test_name: 'build', passed: false, execution_command: 'npm run build', test_purpose: 'Build app', error: 'Build failed' },
+      ];
+      const mockSpawn = createMockSpawn({ result: JSON.stringify(testResults) });
+      (spawn as unknown as ReturnType<typeof vi.fn>).mockImplementation(mockSpawn);
+
+      const result = await runTestAgent(testLogsDir);
+
+      expect(result.testResults).toHaveLength(2);
+      expect(result.allPassed).toBe(false);
+      expect(result.failedTests).toHaveLength(1);
+      expect(result.failedTests[0].test_name).toBe('build');
+    });
+
+    it('handles all tests passing', async () => {
+      const testResults: TestResult[] = [
+        { test_name: 'linting', passed: true, execution_command: 'npm run lint', test_purpose: 'Check linting' },
+        { test_name: 'build', passed: true, execution_command: 'npm run build', test_purpose: 'Build app' },
+      ];
+      const mockSpawn = createMockSpawn({ result: JSON.stringify(testResults) });
+      (spawn as unknown as ReturnType<typeof vi.fn>).mockImplementation(mockSpawn);
+
+      const result = await runTestAgent(testLogsDir);
+
+      expect(result.allPassed).toBe(true);
+      expect(result.failedTests).toHaveLength(0);
+    });
+  });
+
+  describe('runE2ETestAgent', () => {
+    it('uses sonnet model for E2E test execution', async () => {
+      const e2eResult: E2ETestResult = {
+        test_name: 'Login Test',
+        status: 'passed',
+        screenshots: [],
+        error: null,
+      };
+      const mockSpawn = createMockSpawn({ result: JSON.stringify(e2eResult) });
+      (spawn as unknown as ReturnType<typeof vi.fn>).mockImplementation(mockSpawn);
+
+      await runE2ETestAgent('/path/to/test_login.md', testLogsDir);
+
+      expect(spawn).toHaveBeenCalledWith(
+        '/usr/local/bin/claude',
+        expect.arrayContaining(['--model', 'sonnet']),
+        expect.any(Object)
+      );
+    });
+
+    it('parses E2E test result from JSON output', async () => {
+      const e2eResult: E2ETestResult = {
+        test_name: 'Login Test',
+        status: 'failed',
+        screenshots: ['/path/to/screenshot.png'],
+        error: 'Element not found',
+      };
+      const mockSpawn = createMockSpawn({ result: JSON.stringify(e2eResult) });
+      (spawn as unknown as ReturnType<typeof vi.fn>).mockImplementation(mockSpawn);
+
+      const result = await runE2ETestAgent('/path/to/test_login.md', testLogsDir);
+
+      expect(result.e2eResult).not.toBeNull();
+      expect(result.e2eResult?.test_name).toBe('Login Test');
+      expect(result.e2eResult?.status).toBe('failed');
+      expect(result.passed).toBe(false);
+    });
+
+    it('adds test_path to the result', async () => {
+      const e2eResult: E2ETestResult = {
+        test_name: 'Login Test',
+        status: 'passed',
+        screenshots: [],
+        error: null,
+      };
+      const mockSpawn = createMockSpawn({ result: JSON.stringify(e2eResult) });
+      (spawn as unknown as ReturnType<typeof vi.fn>).mockImplementation(mockSpawn);
+
+      const testPath = '/path/to/test_login.md';
+      const result = await runE2ETestAgent(testPath, testLogsDir);
+
+      expect(result.e2eResult?.test_path).toBe(testPath);
+    });
+  });
+
+  describe('runResolveTestAgent', () => {
+    it('uses opus model for failure resolution', async () => {
+      const mockSpawn = createMockSpawn({ result: 'Fixed the issue' });
+      (spawn as unknown as ReturnType<typeof vi.fn>).mockImplementation(mockSpawn);
+
+      const failedTest: TestResult = {
+        test_name: 'build',
+        passed: false,
+        execution_command: 'npm run build',
+        test_purpose: 'Build app',
+        error: 'Type error',
+      };
+
+      await runResolveTestAgent(failedTest, testLogsDir);
+
+      expect(spawn).toHaveBeenCalledWith(
+        '/usr/local/bin/claude',
+        expect.arrayContaining(['--model', 'opus']),
+        expect.any(Object)
+      );
+    });
+
+    it('passes failed test as JSON argument', async () => {
+      const mockSpawn = createMockSpawn({ result: 'Fixed the issue' });
+      (spawn as unknown as ReturnType<typeof vi.fn>).mockImplementation(mockSpawn);
+
+      const failedTest: TestResult = {
+        test_name: 'build',
+        passed: false,
+        execution_command: 'npm run build',
+        test_purpose: 'Build app',
+        error: 'Type error',
+      };
+
+      await runResolveTestAgent(failedTest, testLogsDir);
+
+      // Verify the command was called with the test JSON in the prompt
+      const calls = (spawn as unknown as ReturnType<typeof vi.fn>).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      const args = lastCall[1] as string[];
+      const prompt = args[args.length - 1];
+      expect(prompt).toContain('/resolve_failed_test');
+      expect(prompt).toContain('build');
+    });
+  });
+
+  describe('runResolveE2ETestAgent', () => {
+    it('uses opus model for E2E failure resolution', async () => {
+      const mockSpawn = createMockSpawn({ result: 'Fixed the E2E issue' });
+      (spawn as unknown as ReturnType<typeof vi.fn>).mockImplementation(mockSpawn);
+
+      const failedE2ETest: E2ETestResult = {
+        test_name: 'Login Test',
+        status: 'failed',
+        screenshots: [],
+        error: 'Element not found',
+        test_path: '/path/to/test_login.md',
+      };
+
+      await runResolveE2ETestAgent(failedE2ETest, testLogsDir);
+
+      expect(spawn).toHaveBeenCalledWith(
+        '/usr/local/bin/claude',
+        expect.arrayContaining(['--model', 'opus']),
+        expect.any(Object)
+      );
+    });
+
+    it('passes failed E2E test as JSON argument', async () => {
+      const mockSpawn = createMockSpawn({ result: 'Fixed the E2E issue' });
+      (spawn as unknown as ReturnType<typeof vi.fn>).mockImplementation(mockSpawn);
+
+      const failedE2ETest: E2ETestResult = {
+        test_name: 'Login Test',
+        status: 'failed',
+        screenshots: ['/path/to/screenshot.png'],
+        error: 'Element not found',
+        test_path: '/path/to/test_login.md',
+      };
+
+      await runResolveE2ETestAgent(failedE2ETest, testLogsDir);
+
+      // Verify the command was called with the E2E test JSON in the prompt
+      const calls = (spawn as unknown as ReturnType<typeof vi.fn>).mock.calls;
+      const lastCall = calls[calls.length - 1];
+      const args = lastCall[1] as string[];
+      const prompt = args[args.length - 1];
+      expect(prompt).toContain('/resolve_failed_e2e_test');
+      expect(prompt).toContain('Login Test');
+    });
+  });
+});
+
+/**
+ * Creates a mock implementation of child_process.spawn that simulates
+ * the Claude CLI output format.
+ */
+function createMockSpawn(options: { result: string; exitCode?: number }) {
+  return () => {
+    const { result, exitCode = 0 } = options;
+
+    // Create mock event emitter-like object
+    const mockStdout = {
+      on: vi.fn((event: string, callback: (data: Buffer) => void) => {
+        if (event === 'data') {
+          // Simulate JSONL output format
+          const jsonlOutput = JSON.stringify({
+            type: 'result',
+            subtype: 'success',
+            isError: false,
+            durationMs: 1000,
+            durationApiMs: 900,
+            numTurns: 1,
+            result,
+            sessionId: 'test-session-id',
+            totalCostUsd: 0.01,
+          });
+          setTimeout(() => callback(Buffer.from(jsonlOutput + '\n')), 10);
+        }
+      }),
+    };
+
+    const mockStderr = {
+      on: vi.fn(),
+    };
+
+    const mockProcess = {
+      stdout: mockStdout,
+      stderr: mockStderr,
+      stdin: {
+        write: vi.fn(),
+        end: vi.fn(),
+      },
+      on: vi.fn((event: string, callback: (code: number) => void) => {
+        if (event === 'close') {
+          setTimeout(() => callback(exitCode), 20);
+        }
+      }),
+    };
+
+    return mockProcess;
+  };
+}

--- a/adws/adwPlanBuildTest.tsx
+++ b/adws/adwPlanBuildTest.tsx
@@ -1,0 +1,116 @@
+#!/usr/bin/env npx tsx
+/**
+ * ADW Plan, Build & Test - AI Developer Workflow Orchestrator
+ *
+ * This script orchestrates the complete ADW workflow by calling:
+ * 1. adwPlan.tsx - Planning phase (classification, branch creation, plan generation)
+ * 2. adwBuild.tsx - Build phase (implementation, commit, PR creation)
+ * 3. adwTest.tsx - Test phase (validation tests with automatic failure resolution)
+ *
+ * Usage: npx tsx adws/adwPlanBuildTest.tsx <github-issue-number> [adw-id]
+ *
+ * Environment Requirements:
+ * - ANTHROPIC_API_KEY: Anthropic API key
+ * - CLAUDE_CODE_PATH: Path to Claude CLI (default: /usr/local/bin/claude)
+ * - GITHUB_PAT: (Optional) GitHub Personal Access Token
+ * - MAX_TEST_RETRY_ATTEMPTS: Maximum retry attempts for tests (default: 5)
+ */
+
+import { execSync, SpawnSyncReturns } from 'child_process';
+import { log, generateAdwId } from './core';
+
+/**
+ * Prints usage information and exits.
+ */
+function printUsageAndExit(): never {
+  console.error('Usage: npx tsx adws/adwPlanBuildTest.tsx <github-issue-number> [adw-id]');
+  console.error('');
+  console.error('This orchestrator runs the complete ADW workflow:');
+  console.error('  1. adwPlan.tsx  - Plan generation');
+  console.error('  2. adwBuild.tsx - Implementation and PR creation');
+  console.error('  3. adwTest.tsx  - Validation tests with failure resolution');
+  console.error('');
+  console.error('Environment Requirements:');
+  console.error('  ANTHROPIC_API_KEY        - Anthropic API key');
+  console.error('  CLAUDE_CODE_PATH         - Path to Claude CLI (default: /usr/local/bin/claude)');
+  console.error('  GITHUB_PAT               - (Optional) GitHub Personal Access Token');
+  console.error('  MAX_TEST_RETRY_ATTEMPTS  - Maximum retry attempts for tests (default: 5)');
+  process.exit(1);
+}
+
+/**
+ * Parses and validates command line arguments.
+ */
+function parseArguments(args: string[]): { issueNumber: number; adwId: string } {
+  if (args.length < 1) {
+    printUsageAndExit();
+  }
+
+  const issueNumber = parseInt(args[0], 10);
+  if (isNaN(issueNumber)) {
+    console.error(`Invalid issue number: ${args[0]}`);
+    process.exit(1);
+  }
+
+  const adwId = args[1] || generateAdwId();
+
+  return { issueNumber, adwId };
+}
+
+/**
+ * Executes a subprocess and returns success status.
+ */
+function runSubprocess(command: string, description: string): boolean {
+  log(`Starting: ${description}`, 'info');
+
+  try {
+    execSync(command, { stdio: 'inherit' });
+    log(`Completed: ${description}`, 'success');
+    return true;
+  } catch (error) {
+    const execError = error as SpawnSyncReturns<Buffer>;
+    log(`Failed: ${description} (exit code: ${execError.status})`, 'error');
+    return false;
+  }
+}
+
+/**
+ * Main orchestrator workflow.
+ */
+function main(): void {
+  const args = process.argv.slice(2);
+  const { issueNumber, adwId } = parseArguments(args);
+
+  log('===================================', 'info');
+  log('ADW Plan, Build & Test Orchestrator', 'info');
+  log(`Issue: #${issueNumber}`, 'info');
+  log(`ADW ID: ${adwId}`, 'info');
+  log('===================================', 'info');
+
+  // Phase 1: Run Plan
+  const planCommand = `npx tsx adws/adwPlan.tsx ${issueNumber} ${adwId}`;
+  if (!runSubprocess(planCommand, 'Plan Phase')) {
+    log('Plan phase failed. Aborting workflow.', 'error');
+    process.exit(1);
+  }
+
+  // Phase 2: Run Build
+  const buildCommand = `npx tsx adws/adwBuild.tsx ${issueNumber} ${adwId}`;
+  if (!runSubprocess(buildCommand, 'Build Phase')) {
+    log('Build phase failed. Aborting workflow.', 'error');
+    process.exit(1);
+  }
+
+  // Phase 3: Run Test
+  const testCommand = `npx tsx adws/adwTest.tsx ${adwId}`;
+  if (!runSubprocess(testCommand, 'Test Phase')) {
+    log('Test phase failed.', 'error');
+    process.exit(1);
+  }
+
+  log('===================================', 'info');
+  log('ADW Plan, Build & Test workflow completed!', 'success');
+  log('===================================', 'info');
+}
+
+main();

--- a/adws/adwTest.tsx
+++ b/adws/adwTest.tsx
@@ -1,0 +1,412 @@
+#!/usr/bin/env npx tsx
+/**
+ * ADW Test - AI Developer Workflow Testing Phase
+ *
+ * Usage: npx tsx adws/adwTest.tsx [adw-id]
+ *
+ * Workflow:
+ * 1. Run unit tests using /test command (sonnet model)
+ * 2. If tests fail, run /resolve_failed_test for each failure (opus model)
+ * 3. Retry unit tests after resolution
+ * 4. Discover and run E2E tests using /test_e2e command (sonnet model)
+ * 5. If E2E tests fail, run /resolve_failed_e2e_test for each failure (opus model)
+ * 6. Retry E2E tests after resolution
+ * 7. Continue until all tests pass or MAX_TEST_RETRY_ATTEMPTS exceeded
+ *
+ * Environment Requirements:
+ * - ANTHROPIC_API_KEY: Anthropic API key
+ * - CLAUDE_CODE_PATH: Path to Claude CLI (default: /usr/local/bin/claude)
+ * - MAX_TEST_RETRY_ATTEMPTS: Maximum retry attempts (default: 5)
+ */
+
+import {
+  log,
+  generateAdwId,
+  ensureLogsDirectory,
+  AgentStateManager,
+  AgentState,
+  MAX_TEST_RETRY_ATTEMPTS,
+} from './core';
+import {
+  runTestAgent,
+  runE2ETestAgent,
+  runResolveTestAgent,
+  runResolveE2ETestAgent,
+  discoverE2ETestFiles,
+  TestResult,
+  E2ETestResult,
+} from './agents';
+
+/**
+ * Prints usage information and exits.
+ */
+function printUsageAndExit(): never {
+  console.error('Usage: npx tsx adws/adwTest.tsx [adw-id]');
+  console.error('');
+  console.error('Runs comprehensive validation tests with automatic failure resolution.');
+  console.error('');
+  console.error('Environment Requirements:');
+  console.error('  ANTHROPIC_API_KEY        - Anthropic API key');
+  console.error('  CLAUDE_CODE_PATH         - Path to Claude CLI (default: /usr/local/bin/claude)');
+  console.error('  MAX_TEST_RETRY_ATTEMPTS  - Maximum retry attempts (default: 5)');
+  process.exit(1);
+}
+
+/**
+ * Parses and validates command line arguments.
+ */
+function parseArguments(args: string[]): { adwId: string } {
+  // Check for help flag
+  if (args.includes('--help') || args.includes('-h')) {
+    printUsageAndExit();
+  }
+
+  const adwId = args[0] || generateAdwId();
+
+  return { adwId };
+}
+
+/**
+ * Prints the test phase summary.
+ */
+function printTestSummary(
+  adwId: string,
+  logsDir: string,
+  unitTestsPassed: boolean,
+  e2eTestsPassed: boolean,
+  totalRetries: number,
+  totalCostUsd: number
+): void {
+  log('===================================', 'info');
+  if (unitTestsPassed && e2eTestsPassed) {
+    log('ADW Test workflow completed!', 'success');
+  } else {
+    log('ADW Test workflow failed!', 'error');
+  }
+  log(`ADW ID: ${adwId}`, 'info');
+  log(`Unit tests: ${unitTestsPassed ? 'PASSED' : 'FAILED'}`, unitTestsPassed ? 'success' : 'error');
+  log(`E2E tests: ${e2eTestsPassed ? 'PASSED' : 'FAILED'}`, e2eTestsPassed ? 'success' : 'error');
+  log(`Total retries: ${totalRetries}`, 'info');
+  log(`Logs: ${logsDir}`, 'info');
+
+  if (totalCostUsd > 0) {
+    log(`Cost: $${totalCostUsd.toFixed(4)}`, 'info');
+  }
+
+  log('===================================', 'info');
+}
+
+/**
+ * Runs unit tests with retry logic.
+ * Returns true if all tests pass, false otherwise.
+ */
+async function runUnitTestsWithRetry(
+  logsDir: string,
+  orchestratorStatePath: string,
+  maxRetries: number
+): Promise<{ passed: boolean; costUsd: number; totalRetries: number }> {
+  let retryCount = 0;
+  let costUsd = 0;
+
+  while (retryCount < maxRetries) {
+    log(`Running unit tests (attempt ${retryCount + 1}/${maxRetries})...`, 'info');
+    AgentStateManager.appendLog(orchestratorStatePath, `Unit test attempt ${retryCount + 1}/${maxRetries}`);
+
+    // Initialize test agent state
+    const testAgentStatePath = AgentStateManager.initializeState(
+      AgentStateManager.readState(orchestratorStatePath)?.adwId || '',
+      'test-agent',
+      orchestratorStatePath
+    );
+
+    // Run the /test command
+    const testResult = await runTestAgent(logsDir, testAgentStatePath);
+    costUsd += testResult.totalCostUsd || 0;
+
+    if (!testResult.success) {
+      log('Test agent execution failed', 'error');
+      AgentStateManager.appendLog(orchestratorStatePath, 'Test agent execution failed');
+      retryCount++;
+      continue;
+    }
+
+    // Check if all tests passed
+    if (testResult.allPassed) {
+      log(`All ${testResult.testResults.length} tests passed!`, 'success');
+      AgentStateManager.appendLog(orchestratorStatePath, `All ${testResult.testResults.length} tests passed`);
+      return { passed: true, costUsd, totalRetries: retryCount };
+    }
+
+    // Some tests failed - attempt to resolve
+    const failedTests = testResult.failedTests;
+    log(`${failedTests.length} test(s) failed, attempting resolution...`, 'info');
+    AgentStateManager.appendLog(orchestratorStatePath, `${failedTests.length} test(s) failed`);
+
+    // Resolve each failed test
+    for (const failedTest of failedTests) {
+      log(`Resolving: ${failedTest.test_name}`, 'info');
+      AgentStateManager.appendLog(orchestratorStatePath, `Resolving failed test: ${failedTest.test_name}`);
+
+      const resolverStatePath = AgentStateManager.initializeState(
+        AgentStateManager.readState(orchestratorStatePath)?.adwId || '',
+        'test-resolver-agent',
+        orchestratorStatePath
+      );
+
+      const resolveResult = await runResolveTestAgent(failedTest, logsDir, resolverStatePath);
+      costUsd += resolveResult.totalCostUsd || 0;
+
+      if (!resolveResult.success) {
+        log(`Failed to resolve: ${failedTest.test_name}`, 'error');
+        AgentStateManager.appendLog(orchestratorStatePath, `Failed to resolve: ${failedTest.test_name}`);
+      } else {
+        log(`Resolution attempted for: ${failedTest.test_name}`, 'success');
+        AgentStateManager.appendLog(orchestratorStatePath, `Resolution attempted for: ${failedTest.test_name}`);
+      }
+    }
+
+    retryCount++;
+  }
+
+  log(`Unit tests still failing after ${maxRetries} attempts`, 'error');
+  AgentStateManager.appendLog(orchestratorStatePath, `Unit tests still failing after ${maxRetries} attempts`);
+  return { passed: false, costUsd, totalRetries: retryCount };
+}
+
+/**
+ * Runs E2E tests with retry logic for each test file.
+ * Returns true if all E2E tests pass, false otherwise.
+ */
+async function runE2ETestsWithRetry(
+  logsDir: string,
+  orchestratorStatePath: string,
+  maxRetries: number
+): Promise<{ passed: boolean; costUsd: number; totalRetries: number }> {
+  const e2eTestFiles = discoverE2ETestFiles();
+  let costUsd = 0;
+  let totalRetries = 0;
+
+  if (e2eTestFiles.length === 0) {
+    log('No E2E test files found in e2e-tests/ directory', 'info');
+    AgentStateManager.appendLog(orchestratorStatePath, 'No E2E test files found - skipping E2E tests');
+    return { passed: true, costUsd, totalRetries };
+  }
+
+  log(`Discovered ${e2eTestFiles.length} E2E test file(s)`, 'info');
+  AgentStateManager.appendLog(orchestratorStatePath, `Discovered ${e2eTestFiles.length} E2E test file(s)`);
+
+  // Track failed E2E tests and their retry counts
+  const failedE2ETests: Map<string, { result: E2ETestResult; retryCount: number }> = new Map();
+
+  // Initial run of all E2E tests
+  for (const testFile of e2eTestFiles) {
+    log(`Running E2E test: ${testFile}`, 'info');
+    AgentStateManager.appendLog(orchestratorStatePath, `Running E2E test: ${testFile}`);
+
+    const e2eAgentStatePath = AgentStateManager.initializeState(
+      AgentStateManager.readState(orchestratorStatePath)?.adwId || '',
+      'test-agent',
+      orchestratorStatePath
+    );
+
+    const e2eResult = await runE2ETestAgent(testFile, logsDir, e2eAgentStatePath);
+    costUsd += e2eResult.totalCostUsd || 0;
+
+    if (!e2eResult.passed && e2eResult.e2eResult) {
+      failedE2ETests.set(testFile, { result: e2eResult.e2eResult, retryCount: 0 });
+      log(`E2E test failed: ${testFile}`, 'error');
+      AgentStateManager.appendLog(orchestratorStatePath, `E2E test failed: ${testFile}`);
+    } else if (e2eResult.passed) {
+      log(`E2E test passed: ${testFile}`, 'success');
+      AgentStateManager.appendLog(orchestratorStatePath, `E2E test passed: ${testFile}`);
+    }
+  }
+
+  // Retry loop for failed E2E tests
+  while (failedE2ETests.size > 0) {
+    const testsToRetry = Array.from(failedE2ETests.entries());
+
+    for (const [testFile, { result, retryCount }] of testsToRetry) {
+      if (retryCount >= maxRetries) {
+        log(`E2E test ${testFile} exceeded max retries`, 'error');
+        AgentStateManager.appendLog(orchestratorStatePath, `E2E test ${testFile} exceeded max retries`);
+        continue;
+      }
+
+      // Attempt to resolve the failure
+      log(`Resolving E2E test: ${result.test_name} (attempt ${retryCount + 1}/${maxRetries})`, 'info');
+      AgentStateManager.appendLog(orchestratorStatePath, `Resolving E2E test: ${result.test_name}`);
+
+      const resolverStatePath = AgentStateManager.initializeState(
+        AgentStateManager.readState(orchestratorStatePath)?.adwId || '',
+        'test-resolver-agent',
+        orchestratorStatePath
+      );
+
+      const resolveResult = await runResolveE2ETestAgent(result, logsDir, resolverStatePath);
+      costUsd += resolveResult.totalCostUsd || 0;
+      totalRetries++;
+
+      // Re-run the E2E test
+      log(`Re-running E2E test: ${testFile}`, 'info');
+      const e2eAgentStatePath = AgentStateManager.initializeState(
+        AgentStateManager.readState(orchestratorStatePath)?.adwId || '',
+        'test-agent',
+        orchestratorStatePath
+      );
+
+      const retryResult = await runE2ETestAgent(testFile, logsDir, e2eAgentStatePath);
+      costUsd += retryResult.totalCostUsd || 0;
+
+      if (retryResult.passed) {
+        failedE2ETests.delete(testFile);
+        log(`E2E test now passing: ${testFile}`, 'success');
+        AgentStateManager.appendLog(orchestratorStatePath, `E2E test now passing: ${testFile}`);
+      } else if (retryResult.e2eResult) {
+        failedE2ETests.set(testFile, { result: retryResult.e2eResult, retryCount: retryCount + 1 });
+        log(`E2E test still failing: ${testFile}`, 'error');
+        AgentStateManager.appendLog(orchestratorStatePath, `E2E test still failing: ${testFile}`);
+      }
+    }
+
+    // Check if all remaining tests have exceeded max retries
+    const allExceededMaxRetries = Array.from(failedE2ETests.values()).every(
+      ({ retryCount }) => retryCount >= maxRetries
+    );
+    if (allExceededMaxRetries) {
+      break;
+    }
+  }
+
+  const allPassed = failedE2ETests.size === 0;
+  if (allPassed) {
+    log('All E2E tests passed!', 'success');
+    AgentStateManager.appendLog(orchestratorStatePath, 'All E2E tests passed');
+  } else {
+    log(`${failedE2ETests.size} E2E test(s) still failing`, 'error');
+    AgentStateManager.appendLog(orchestratorStatePath, `${failedE2ETests.size} E2E test(s) still failing`);
+  }
+
+  return { passed: allPassed, costUsd, totalRetries };
+}
+
+/**
+ * Main test workflow.
+ */
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const { adwId } = parseArguments(args);
+
+  const logsDir = ensureLogsDirectory(adwId);
+
+  log('===================================', 'info');
+  log('ADW Test Workflow', 'info');
+  log(`ADW ID: ${adwId}`, 'info');
+  log(`Max retry attempts: ${MAX_TEST_RETRY_ATTEMPTS}`, 'info');
+  log(`Logs: ${logsDir}`, 'info');
+  log('===================================', 'info');
+
+  // Initialize orchestrator state
+  const orchestratorStatePath = AgentStateManager.initializeState(adwId, 'test-orchestrator');
+
+  const initialState: Partial<AgentState> = {
+    adwId,
+    issueNumber: 0, // Test workflow doesn't require an issue number
+    agentName: 'test-orchestrator',
+    execution: AgentStateManager.createExecutionState('running'),
+    metadata: {
+      maxRetryAttempts: MAX_TEST_RETRY_ATTEMPTS,
+    },
+  };
+  AgentStateManager.writeState(orchestratorStatePath, initialState);
+  AgentStateManager.appendLog(orchestratorStatePath, 'Starting ADW Test workflow');
+
+  try {
+    let totalCostUsd = 0;
+    let totalRetries = 0;
+
+    // Phase 1: Run Unit Tests
+    log('Phase 1: Unit Tests', 'info');
+    AgentStateManager.appendLog(orchestratorStatePath, 'Starting Phase 1: Unit Tests');
+
+    const unitTestsResult = await runUnitTestsWithRetry(
+      logsDir,
+      orchestratorStatePath,
+      MAX_TEST_RETRY_ATTEMPTS
+    );
+    totalCostUsd += unitTestsResult.costUsd;
+    totalRetries += unitTestsResult.totalRetries;
+
+    // Phase 2: Run E2E Tests (only if unit tests pass)
+    let e2eTestsPassed = true;
+    if (unitTestsResult.passed) {
+      log('Phase 2: E2E Tests', 'info');
+      AgentStateManager.appendLog(orchestratorStatePath, 'Starting Phase 2: E2E Tests');
+
+      const e2eTestsResult = await runE2ETestsWithRetry(
+        logsDir,
+        orchestratorStatePath,
+        MAX_TEST_RETRY_ATTEMPTS
+      );
+      totalCostUsd += e2eTestsResult.costUsd;
+      totalRetries += e2eTestsResult.totalRetries;
+      e2eTestsPassed = e2eTestsResult.passed;
+    } else {
+      log('Skipping E2E tests due to unit test failures', 'info');
+      AgentStateManager.appendLog(orchestratorStatePath, 'Skipping E2E tests due to unit test failures');
+    }
+
+    // Update final orchestrator state
+    const allPassed = unitTestsResult.passed && e2eTestsPassed;
+    AgentStateManager.writeState(orchestratorStatePath, {
+      execution: AgentStateManager.completeExecution(
+        AgentStateManager.createExecutionState('running'),
+        allPassed,
+        allPassed ? undefined : 'Some tests failed after maximum retry attempts'
+      ),
+      metadata: {
+        maxRetryAttempts: MAX_TEST_RETRY_ATTEMPTS,
+        unitTestsPassed: unitTestsResult.passed,
+        e2eTestsPassed,
+        totalRetries,
+        totalCostUsd,
+      },
+    });
+
+    if (allPassed) {
+      AgentStateManager.appendLog(orchestratorStatePath, 'Test workflow completed successfully');
+    } else {
+      AgentStateManager.appendLog(orchestratorStatePath, 'Test workflow completed with failures');
+    }
+
+    // Print summary
+    printTestSummary(
+      adwId,
+      logsDir,
+      unitTestsResult.passed,
+      e2eTestsPassed,
+      totalRetries,
+      totalCostUsd
+    );
+
+    // Exit with appropriate code
+    if (!allPassed) {
+      process.exit(1);
+    }
+
+  } catch (error) {
+    AgentStateManager.writeState(orchestratorStatePath, {
+      execution: AgentStateManager.completeExecution(
+        AgentStateManager.createExecutionState('running'),
+        false,
+        String(error)
+      ),
+    });
+    AgentStateManager.appendLog(orchestratorStatePath, `Test workflow failed: ${error}`);
+
+    log(`Test workflow failed: ${error}`, 'error');
+    process.exit(1);
+  }
+}
+
+main();

--- a/adws/agents/index.ts
+++ b/adws/agents/index.ts
@@ -25,3 +25,16 @@ export {
   runPrReviewBuildAgent,
   runBuildAgent,
 } from './buildAgent';
+
+// Test Agent
+export {
+  runTestAgent,
+  runE2ETestAgent,
+  runResolveTestAgent,
+  runResolveE2ETestAgent,
+  discoverE2ETestFiles,
+  type TestResult,
+  type E2ETestResult,
+  type TestAgentResult,
+  type E2ETestAgentResult,
+} from './testAgent';

--- a/adws/agents/testAgent.ts
+++ b/adws/agents/testAgent.ts
@@ -1,0 +1,263 @@
+/**
+ * Test Agent - Runs test commands and resolves failures.
+ * Uses slash commands from .claude/commands/ for consistent prompt templates.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { runClaudeAgentWithCommand, AgentResult } from './claudeAgent';
+
+/**
+ * Individual test result from the /test command.
+ * Matches the JSON output structure defined in .claude/commands/test.md
+ */
+export interface TestResult {
+  test_name: string;
+  passed: boolean;
+  execution_command: string;
+  test_purpose: string;
+  error?: string;
+}
+
+/**
+ * E2E test result from the /test_e2e command.
+ * Matches the JSON output structure defined in .claude/commands/test_e2e.md
+ */
+export interface E2ETestResult {
+  test_name: string;
+  status: 'passed' | 'failed';
+  screenshots: string[];
+  error: string | null;
+  /** The path to the test file (added for resolution context) */
+  test_path?: string;
+}
+
+/**
+ * Aggregated result from running the /test command.
+ */
+export interface TestAgentResult extends AgentResult {
+  /** Parsed test results from the JSON output */
+  testResults: TestResult[];
+  /** Overall success status (all tests passed) */
+  allPassed: boolean;
+  /** Failed tests for resolution */
+  failedTests: TestResult[];
+}
+
+/**
+ * Result from running the /test_e2e command for a single test file.
+ */
+export interface E2ETestAgentResult extends AgentResult {
+  /** Parsed E2E test result from the JSON output */
+  e2eResult: E2ETestResult | null;
+  /** Whether the E2E test passed */
+  passed: boolean;
+}
+
+/**
+ * Parses JSON test results from agent output.
+ * Handles cases where the output contains additional text around the JSON.
+ */
+function parseTestResults(output: string): TestResult[] {
+  try {
+    // Try direct JSON parse first
+    return JSON.parse(output);
+  } catch {
+    // Try to extract JSON array from the output
+    const jsonMatch = output.match(/\[[\s\S]*\]/);
+    if (jsonMatch) {
+      try {
+        return JSON.parse(jsonMatch[0]);
+      } catch {
+        return [];
+      }
+    }
+    return [];
+  }
+}
+
+/**
+ * Parses E2E test result from agent output.
+ * Handles cases where the output contains additional text around the JSON.
+ */
+function parseE2ETestResult(output: string): E2ETestResult | null {
+  try {
+    // Try direct JSON parse first
+    return JSON.parse(output);
+  } catch {
+    // Try to extract JSON object from the output
+    const jsonMatch = output.match(/\{[\s\S]*\}/);
+    if (jsonMatch) {
+      try {
+        return JSON.parse(jsonMatch[0]);
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
+}
+
+/**
+ * Runs the /test command and returns parsed test results.
+ * Uses 'sonnet' model for cost efficiency.
+ *
+ * @param logsDir - Directory to write agent logs
+ * @param statePath - Optional path to agent's state directory for state tracking
+ */
+export async function runTestAgent(
+  logsDir: string,
+  statePath?: string
+): Promise<TestAgentResult> {
+  const outputFile = path.join(logsDir, 'test-agent.jsonl');
+
+  // Run /test command with empty args (command has no required arguments)
+  const result = await runClaudeAgentWithCommand(
+    '/test',
+    '',
+    'Test Runner',
+    outputFile,
+    'sonnet',
+    undefined,
+    statePath
+  );
+
+  // Parse the test results from the output
+  const testResults = parseTestResults(result.output);
+  const failedTests = testResults.filter(t => !t.passed);
+  const allPassed = testResults.length > 0 && failedTests.length === 0;
+
+  return {
+    ...result,
+    testResults,
+    allPassed,
+    failedTests,
+  };
+}
+
+/**
+ * Runs the /test_e2e command for a specific E2E test file.
+ * Uses 'sonnet' model for cost efficiency.
+ *
+ * @param testFilePath - Path to the E2E test file
+ * @param logsDir - Directory to write agent logs
+ * @param statePath - Optional path to agent's state directory for state tracking
+ */
+export async function runE2ETestAgent(
+  testFilePath: string,
+  logsDir: string,
+  statePath?: string
+): Promise<E2ETestAgentResult> {
+  const testName = path.basename(testFilePath, '.md');
+  const outputFile = path.join(logsDir, `e2e-test-agent-${testName}.jsonl`);
+
+  // Run /test_e2e command with the test file path as argument
+  const result = await runClaudeAgentWithCommand(
+    '/test_e2e',
+    testFilePath,
+    `E2E Test: ${testName}`,
+    outputFile,
+    'sonnet',
+    undefined,
+    statePath
+  );
+
+  // Parse the E2E test result from the output
+  const e2eResult = parseE2ETestResult(result.output);
+  const passed = e2eResult?.status === 'passed';
+
+  // Add test_path to the result for resolution context
+  if (e2eResult) {
+    e2eResult.test_path = testFilePath;
+  }
+
+  return {
+    ...result,
+    e2eResult,
+    passed,
+  };
+}
+
+/**
+ * Runs the /resolve_failed_test command with failure details.
+ * Uses 'opus' model for complex reasoning.
+ *
+ * @param failedTest - The test result that failed
+ * @param logsDir - Directory to write agent logs
+ * @param statePath - Optional path to agent's state directory for state tracking
+ */
+export async function runResolveTestAgent(
+  failedTest: TestResult,
+  logsDir: string,
+  statePath?: string
+): Promise<AgentResult> {
+  const outputFile = path.join(logsDir, `resolve-test-${failedTest.test_name}.jsonl`);
+
+  // Format the failed test as JSON for the resolver
+  const failureJson = JSON.stringify(failedTest, null, 2);
+
+  return runClaudeAgentWithCommand(
+    '/resolve_failed_test',
+    failureJson,
+    `Resolve: ${failedTest.test_name}`,
+    outputFile,
+    'opus',
+    undefined,
+    statePath
+  );
+}
+
+/**
+ * Runs the /resolve_failed_e2e_test command with failure details.
+ * Uses 'opus' model for complex reasoning.
+ *
+ * @param failedE2ETest - The E2E test result that failed
+ * @param logsDir - Directory to write agent logs
+ * @param statePath - Optional path to agent's state directory for state tracking
+ */
+export async function runResolveE2ETestAgent(
+  failedE2ETest: E2ETestResult,
+  logsDir: string,
+  statePath?: string
+): Promise<AgentResult> {
+  const testName = failedE2ETest.test_name.replace(/\s+/g, '-').toLowerCase();
+  const outputFile = path.join(logsDir, `resolve-e2e-${testName}.jsonl`);
+
+  // Format the failed E2E test as JSON for the resolver
+  const failureJson = JSON.stringify(failedE2ETest, null, 2);
+
+  return runClaudeAgentWithCommand(
+    '/resolve_failed_e2e_test',
+    failureJson,
+    `Resolve E2E: ${failedE2ETest.test_name}`,
+    outputFile,
+    'opus',
+    undefined,
+    statePath
+  );
+}
+
+/**
+ * Discovers E2E test files in the e2e-tests directory.
+ * Returns an array of paths to markdown test files.
+ *
+ * @returns Array of absolute paths to E2E test files
+ */
+export function discoverE2ETestFiles(): string[] {
+  const e2eTestsDir = path.join(process.cwd(), 'e2e-tests');
+
+  // Return empty array if directory doesn't exist
+  if (!fs.existsSync(e2eTestsDir)) {
+    return [];
+  }
+
+  try {
+    const files = fs.readdirSync(e2eTestsDir);
+    return files
+      .filter(file => file.endsWith('.md'))
+      .map(file => path.join(e2eTestsDir, file))
+      .sort();
+  } catch {
+    return [];
+  }
+}

--- a/adws/core/config.ts
+++ b/adws/core/config.ts
@@ -22,3 +22,6 @@ export const SPECS_DIR = path.join(process.cwd(), 'specs');
 
 /** Directory for storing agent state files. */
 export const AGENTS_STATE_DIR = path.join(process.cwd(), 'agents');
+
+/** Maximum number of retry attempts for test resolution. */
+export const MAX_TEST_RETRY_ATTEMPTS = parseInt(process.env.MAX_TEST_RETRY_ATTEMPTS || '5', 10);

--- a/adws/core/dataTypes.ts
+++ b/adws/core/dataTypes.ts
@@ -196,7 +196,12 @@ export type WorkflowStage =
   | 'pr_creating'
   | 'pr_created'
   | 'completed'
-  | 'error';
+  | 'error'
+  // Test workflow stages
+  | 'test_running'
+  | 'test_failed'
+  | 'test_resolving'
+  | 'test_passed';
 
 /**
  * PR review comment from GitHub API.
@@ -301,7 +306,11 @@ export type AgentIdentifier =
   | 'plan-agent'
   | 'build-agent'
   | 'pr-review-plan-agent'
-  | 'pr-review-build-agent';
+  | 'pr-review-build-agent'
+  // Test workflow agents
+  | 'test-orchestrator'
+  | 'test-agent'
+  | 'test-resolver-agent';
 
 /**
  * Execution status for tracking agent progress.

--- a/adws/core/index.ts
+++ b/adws/core/index.ts
@@ -3,7 +3,7 @@
  */
 
 // Configuration
-export { CLAUDE_CODE_PATH, GITHUB_PAT, LOGS_DIR, SPECS_DIR, AGENTS_STATE_DIR } from './config';
+export { CLAUDE_CODE_PATH, GITHUB_PAT, LOGS_DIR, SPECS_DIR, AGENTS_STATE_DIR, MAX_TEST_RETRY_ATTEMPTS } from './config';
 
 // Data types
 export type {

--- a/specs/issue-36-plan.md
+++ b/specs/issue-36-plan.md
@@ -1,0 +1,254 @@
+# Feature: adwTest and adwPlanBuildTest ADWs
+
+## Feature Description
+Create two new AI Developer Workflow (ADW) scripts:
+1. **adwTest** - Runs comprehensive validation tests (`/test` and `/test_e2e`) with automatic failure resolution using retry logic
+2. **adwPlanBuildTest** - Orchestrates the complete development workflow by executing adwPlan, adwBuild, and adwTest in sequence
+
+The adwTest ADW will invoke test agents using the Claude 'sonnet' model for cost efficiency, but switch to the Claude 'opus' model when invoking failure resolution agents for more complex reasoning. It implements retry logic controlled by the `MAX_TEST_RETRY_ATTEMPTS` environment variable (default: 5).
+
+## User Story
+As a developer
+I want an automated test runner that can detect and resolve test failures
+So that I can run comprehensive validation with automatic error correction
+
+## Problem Statement
+Currently, the ADW system has adwPlan and adwBuild phases but lacks an automated testing phase. When tests fail during development:
+- Developers must manually identify and fix failing tests
+- There's no retry mechanism for transient failures
+- The workflow stops without attempting to resolve issues
+
+## Solution Statement
+Create an adwTest ADW that:
+1. Runs the `/test` command (unit tests, linting, type checks, build)
+2. Runs the `/test_e2e` command for each E2E test file
+3. When tests fail, invokes `/resolve_failed_test` or `/resolve_failed_e2e_test` with the failure details
+4. Retries failed tests up to MAX_TEST_RETRY_ATTEMPTS times
+5. Uses 'sonnet' model for test execution and 'opus' model for failure resolution
+
+Additionally, create an adwPlanBuildTest orchestrator that runs the complete workflow: Plan → Build → Test.
+
+## Relevant Files
+Use these files to implement the feature:
+
+- `adws/adwPlanBuild.tsx` - Existing orchestrator pattern showing how to chain adw scripts sequentially
+- `adws/adwPlan.tsx` - Existing plan ADW for reference on workflow structure and error handling
+- `adws/adwBuild.tsx` - Existing build ADW for reference on workflow structure and state management
+- `adws/agents/claudeAgent.ts` - Contains `runClaudeAgentWithCommand()` for invoking slash commands with specific models
+- `adws/agents/index.ts` - Exports agent functions, will need to export new test agent functions
+- `adws/core/config.ts` - Configuration constants, will need MAX_TEST_RETRY_ATTEMPTS
+- `adws/core/dataTypes.ts` - Type definitions, may need new workflow stages for test phase
+- `adws/core/index.ts` - Re-exports core utilities
+- `.claude/commands/test.md` - The `/test` slash command that runs unit tests, linting, type checks, and build
+- `.claude/commands/test_e2e.md` - The `/test_e2e` slash command for E2E tests using Playwright
+- `.claude/commands/resolve_failed_test.md` - Command for resolving failed unit/build tests
+- `.claude/commands/resolve_failed_e2e_test.md` - Command for resolving failed E2E tests
+
+### New Files
+- `adws/adwTest.tsx` - New ADW script for test execution with retry logic
+- `adws/adwPlanBuildTest.tsx` - New orchestrator that runs Plan → Build → Test
+- `adws/agents/testAgent.ts` - Agent functions for running tests and resolving failures
+- `adws/__tests__/testAgent.test.ts` - Unit tests for the test agent functions
+
+## Implementation Plan
+### Phase 1: Foundation
+1. Add MAX_TEST_RETRY_ATTEMPTS configuration constant to `adws/core/config.ts`
+2. Add new workflow stages for test phase to `adws/core/dataTypes.ts`
+3. Create test agent functions in `adws/agents/testAgent.ts`
+
+### Phase 2: Core Implementation
+1. Implement `adwTest.tsx` with:
+   - Test execution using `/test` command
+   - E2E test discovery and execution using `/test_e2e` command
+   - Failure detection and resolution using `/resolve_failed_test` and `/resolve_failed_e2e_test`
+   - Retry loop with MAX_TEST_RETRY_ATTEMPTS limit
+   - Model switching (sonnet for tests, opus for resolution)
+
+### Phase 3: Integration
+1. Create `adwPlanBuildTest.tsx` orchestrator that chains adwPlan → adwBuild → adwTest
+2. Export new agent functions from `adws/agents/index.ts`
+3. Add unit tests for the new test agent functions
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### Step 1: Add MAX_TEST_RETRY_ATTEMPTS configuration
+
+Update `adws/core/config.ts` to add the new environment variable:
+- Add `MAX_TEST_RETRY_ATTEMPTS` constant that reads from `process.env.MAX_TEST_RETRY_ATTEMPTS`
+- Default value should be 5
+- Parse as integer from environment
+
+### Step 2: Add test workflow stages to dataTypes.ts
+
+Update `adws/core/dataTypes.ts` to add new workflow stages:
+- Add to `WorkflowStage` type: `'test_running'`, `'test_failed'`, `'test_resolving'`, `'test_passed'`
+- Add new `AgentIdentifier` values: `'test-orchestrator'`, `'test-agent'`, `'test-resolver-agent'`
+
+### Step 3: Create test agent functions
+
+Create `adws/agents/testAgent.ts` with the following functions:
+
+```typescript
+/**
+ * Runs the /test command and returns parsed test results.
+ * Uses 'sonnet' model for cost efficiency.
+ */
+export async function runTestAgent(
+  logsDir: string,
+  statePath?: string
+): Promise<TestAgentResult>
+
+/**
+ * Runs the /test_e2e command for a specific E2E test file.
+ * Uses 'sonnet' model for cost efficiency.
+ */
+export async function runE2ETestAgent(
+  testFilePath: string,
+  logsDir: string,
+  statePath?: string
+): Promise<E2ETestAgentResult>
+
+/**
+ * Runs the /resolve_failed_test command with failure details.
+ * Uses 'opus' model for complex reasoning.
+ */
+export async function runResolveTestAgent(
+  failedTest: TestResult,
+  logsDir: string,
+  statePath?: string
+): Promise<AgentResult>
+
+/**
+ * Runs the /resolve_failed_e2e_test command with failure details.
+ * Uses 'opus' model for complex reasoning.
+ */
+export async function runResolveE2ETestAgent(
+  failedE2ETest: E2ETestResult,
+  logsDir: string,
+  statePath?: string
+): Promise<AgentResult>
+
+/**
+ * Discovers E2E test files in the e2e-tests directory.
+ */
+export function discoverE2ETestFiles(): string[]
+```
+
+Define interfaces:
+- `TestResult` - Matches the JSON output from `/test` command
+- `E2ETestResult` - Matches the JSON output from `/test_e2e` command
+- `TestAgentResult` - Contains success status and array of TestResult
+- `E2ETestAgentResult` - Contains success status and E2ETestResult
+
+### Step 4: Update agents/index.ts exports
+
+Add exports for the new test agent functions:
+- Export `runTestAgent`, `runE2ETestAgent`, `runResolveTestAgent`, `runResolveE2ETestAgent`, `discoverE2ETestFiles`
+- Export the new types: `TestResult`, `E2ETestResult`, `TestAgentResult`, `E2ETestAgentResult`
+
+### Step 5: Create adwTest.tsx
+
+Create `adws/adwTest.tsx` with the following workflow:
+
+1. **Argument Parsing**: Accept `[adw-id]` as optional argument
+2. **Initialize State**: Create test-orchestrator state
+3. **Run Unit Tests**:
+   - Invoke `/test` command using 'sonnet' model
+   - Parse JSON output to get test results
+   - Identify any failed tests
+4. **Resolve Unit Test Failures**:
+   - For each failed test, invoke `/resolve_failed_test` with 'opus' model
+   - Pass the test failure JSON as argument
+5. **Retry Unit Tests**: If failures were resolved, re-run `/test`
+6. **Run E2E Tests**:
+   - Discover E2E test files in `e2e-tests/` directory
+   - For each test file, invoke `/test_e2e` with 'sonnet' model
+   - Parse JSON output to get test results
+7. **Resolve E2E Test Failures**:
+   - For each failed E2E test, invoke `/resolve_failed_e2e_test` with 'opus' model
+   - Pass the E2E failure JSON as argument
+8. **Retry E2E Tests**: If failures were resolved, re-run the specific E2E test
+9. **Retry Loop**:
+   - Continue retrying until all tests pass or attempt count exceeds MAX_TEST_RETRY_ATTEMPTS
+   - Log each retry attempt
+10. **Report Results**: Print summary of passed/failed tests
+
+The script should:
+- Exit with code 0 if all tests pass
+- Exit with code 1 if tests still fail after max retries
+- Log progress and status throughout
+
+### Step 6: Create adwPlanBuildTest.tsx
+
+Create `adws/adwPlanBuildTest.tsx` modeled after `adwPlanBuild.tsx`:
+
+1. **Argument Parsing**: Accept `<github-issue-number> [adw-id]`
+2. **Run Plan Phase**: Execute `npx tsx adws/adwPlan.tsx <issue> <adw-id>`
+3. **Run Build Phase**: Execute `npx tsx adws/adwBuild.tsx <issue> <adw-id>`
+4. **Run Test Phase**: Execute `npx tsx adws/adwTest.tsx <adw-id>`
+5. **Error Handling**: Stop workflow if any phase fails
+6. **Summary**: Print overall workflow completion status
+
+### Step 7: Create unit tests for testAgent
+
+Create `adws/__tests__/testAgent.test.ts` with tests for:
+- `discoverE2ETestFiles()` - Test E2E file discovery
+- `runTestAgent()` - Mock Claude CLI and verify output parsing
+- `runE2ETestAgent()` - Mock Claude CLI and verify output parsing
+- `runResolveTestAgent()` - Verify opus model is used
+- `runResolveE2ETestAgent()` - Verify opus model is used
+
+Mock the `child_process` module similar to existing tests in `adws/__tests__/`.
+
+### Step 8: Run validation commands
+
+Execute the validation commands to ensure all changes work correctly with zero regressions.
+
+## Testing Strategy
+### Unit Tests
+- Test `discoverE2ETestFiles()` returns correct file paths
+- Test test agent functions correctly parse JSON output from `/test` command
+- Test E2E test agent functions correctly parse JSON output from `/test_e2e` command
+- Test resolver agents use 'opus' model
+- Test retry logic respects MAX_TEST_RETRY_ATTEMPTS limit
+
+### Integration Tests
+- Test adwTest.tsx runs to completion with mock test results
+- Test adwPlanBuildTest.tsx chains all phases correctly
+
+### Edge Cases
+- No E2E test files exist (should skip E2E tests gracefully)
+- All tests pass on first attempt (no resolution needed)
+- Tests fail and cannot be resolved after max retries
+- Invalid JSON output from test agents
+- Test command times out
+
+## Acceptance Criteria
+- [ ] adwTest.tsx runs `/test` command using 'sonnet' model
+- [ ] adwTest.tsx runs `/test_e2e` command for each E2E test file using 'sonnet' model
+- [ ] adwTest.tsx invokes `/resolve_failed_test` with 'opus' model when unit tests fail
+- [ ] adwTest.tsx invokes `/resolve_failed_e2e_test` with 'opus' model when E2E tests fail
+- [ ] adwTest.tsx retries failed tests up to MAX_TEST_RETRY_ATTEMPTS times
+- [ ] MAX_TEST_RETRY_ATTEMPTS defaults to 5 and can be configured via environment variable
+- [ ] adwPlanBuildTest.tsx executes adwPlan, adwBuild, and adwTest in sequence
+- [ ] adwPlanBuildTest.tsx stops workflow if any phase fails
+- [ ] All existing tests pass
+- [ ] Linting passes
+- [ ] Build succeeds
+
+## Validation Commands
+Execute every command to validate the feature works correctly with zero regressions.
+
+- `npm run lint` - Run linter to check for code quality issues
+- `npm run build` - Build the application to verify no build errors
+- `npm test` - Run tests to validate the feature works with zero regressions
+- `npx tsc --noEmit -p adws/tsconfig.json` - Verify ADW TypeScript compiles correctly
+
+## Notes
+- The `/test` command outputs JSON array of test results that can be parsed to identify failures
+- The `/test_e2e` command outputs JSON with test name, status, screenshots, and error fields
+- E2E tests are stored as markdown files in an `e2e-tests/` directory (to be created when needed)
+- The retry logic should track which specific tests failed and only retry those
+- When no E2E tests exist, the E2E phase should complete successfully with a log message
+- Consider adding workflow comments to GitHub issues for adwTest (similar to adwPlan/adwBuild) in a future enhancement


### PR DESCRIPTION
## Summary
Implements #36 - Create a new adw, adwTest

## Implementation Plan


## Changes Made
## Report

### Summary of Work Done

- **Added `MAX_TEST_RETRY_ATTEMPTS` configuration** to `adws/core/config.ts` - Environment variable-based configuration with default value of 5
- **Added test workflow stages** to `adws/core/dataTypes.ts`:
  - New `WorkflowStage` values: `test_running`, `test_failed`, `test_resolving`, `test_passed`
  - New `AgentIdentifier` values: `test-orchestrator`, `test-agent`, `test-resolver-agent`
- **Created `adws/agents/testAgent.ts`** with test agent functions:
  - `runTestAgent()` - Runs `/test` command with sonnet model
  - `runE2ETestAgent()` - Runs `/test_e2e` command with sonnet model
  - `runResolveTestAgent()` - Runs `/resolve_failed_test` with opus model
  - `runResolveE2ETestAgent()` - Runs `/resolve_failed_e2e_test` with opus model
  - `discoverE2ETestFiles()` - Discovers E2E test files in `e2e-tests/` directory
  - Defined interfaces: `TestResult`, `E2ETestResult`, `TestAgentResult`, `E2ETestAgentResult`
- **Updated `adws/agents/index.ts`** to export all new test agent functions and types
- **Updated `adws/core/index.ts`** to export `MAX_TEST_RETRY_ATTEMPTS`
- **Created `adws/adwTest.tsx`** - Test workflow ADW with retry logic for unit tests and E2E tests
- **Created `adws/adwPlanBuildTest.tsx`** - Orchestrator that chains Plan → Build → Test phases
- **Created `adws/__tests__/testAgent.test.ts`** with 14 unit tests covering all test agent functions

### Files Changed

```
 adws/agents/index.ts              |  13 +++
 adws/core/config.ts               |   3 +++
 adws/core/dataTypes.ts            |  13 ++-
 adws/core/index.ts                |   2 +-
 adws/__tests__/testAgent.test.ts  | 337 +++ (new file)
 adws/adwPlanBuildTest.tsx         | 116 +++ (new file)
 adws/adwTest.tsx                  | 412 +++ (new file)
 adws/agents/testAgent.ts          | 263 +++ (new file)
```

**Total: 8 files changed, 1156 lines added**

### Validation Results
- ✅ `npm run lint` - No ESLint warnings or errors
- ✅ `npm run build` - Build succeeded
- ✅ `npm test` - All 60 tests passed (including 14 new testAgent tests)
- ✅ `npx tsc --noEmit -p adws/tsconfig.json` - ADW TypeScript compiled successfully
- ✅ `npx tsc --noEmit` - Main TypeScript compiled successfully

## Testing
- [ ] All validation commands from the plan pass
- [ ] No regressions introduced
- [ ] Code follows project conventions

---
Generated by ADW Plan & Build workflow
