### PR TITLE
feat: Update triggers to use adwPlanBuildTest for bugs and features (#40)

### DIFF
--- a/.claude/commands/classify_issue.md
+++ b/.claude/commands/classify_issue.md
@@ -11,9 +11,17 @@ Based on the `Github Issue` below, follow the `Instructions` to select the appro
 
 ## Command Mapping
 
-- Respond with `/chore` if the issue is a chore.
-- Respond with `/bug` if the issue is a bug.
-- Respond with `/feature` if the issue is a feature.
+- Respond with `/chore` if the issue is a chore that is **unlikely to require new or modified tests**. Chores include:
+  - Documentation-only changes (README, docs, comments)
+  - Configuration file updates (tsconfig, eslint, prettier configs)
+  - Dependency version updates
+  - CI/CD pipeline changes
+  - Code style/formatting changes
+  - Refactoring with no functional changes
+  - File/folder reorganization
+  - **Important:** If the change might require new tests or modifications to existing tests, classify it as `/feature` instead.
+- Respond with `/bug` if the issue is a bug fix. Bug fixes address existing functionality that is not working as expected.
+- Respond with `/feature` if the issue is a feature or enhancement. Features add new functionality or modify existing behavior in ways that may require new tests.
 - Respond with `/pr_review` if the issue is requesting a PR review, code review, or review-related changes.
 - Respond with `0` if the issue isn't any of the above.
 

--- a/adws/triggers/issueClassifier.ts
+++ b/adws/triggers/issueClassifier.ts
@@ -1,0 +1,89 @@
+/**
+ * Issue classifier helper for ADW triggers.
+ *
+ * Provides classification functionality for determining which workflow
+ * script to spawn based on issue type.
+ */
+
+import { fetchGitHubIssue } from '../github/githubApi';
+import { runClaudeAgentWithCommand } from '../agents/claudeAgent';
+import { IssueClassSlashCommand, log } from '../core';
+
+/**
+ * Result of classifying an issue for trigger purposes.
+ */
+export interface IssueClassificationResult {
+  issueType: IssueClassSlashCommand;
+  success: boolean;
+}
+
+/**
+ * Classifies an issue to determine the appropriate workflow.
+ *
+ * @param issueNumber - The GitHub issue number to classify
+ * @returns Classification result with issue type and success status
+ */
+export async function classifyIssueForTrigger(
+  issueNumber: number
+): Promise<IssueClassificationResult> {
+  try {
+    log(`Classifying issue #${issueNumber} for trigger...`);
+
+    // Fetch issue details
+    const issue = await fetchGitHubIssue(issueNumber);
+    const issueContext = `**#${issue.number}: ${issue.title}**\n\n${issue.body}`;
+
+    // Run the classifier agent with haiku for fast, cost-effective classification
+    const result = await runClaudeAgentWithCommand(
+      '/classify_issue',
+      issueContext,
+      `trigger-classifier-${issueNumber}`,
+      `/tmp/adw-trigger-classifier-${issueNumber}.jsonl`,
+      'haiku'
+    );
+
+    if (!result.success) {
+      log(`Classification failed for issue #${issueNumber}, defaulting to /feature`, 'error');
+      return { issueType: '/feature', success: false };
+    }
+
+    // Parse the classification result - expect a slash command response
+    const output = result.output.trim();
+    const validCommands: IssueClassSlashCommand[] = ['/chore', '/bug', '/feature', '/pr_review'];
+    const matchedCommand = validCommands.find((cmd) => output.includes(cmd));
+
+    if (matchedCommand) {
+      log(`Issue #${issueNumber} classified as ${matchedCommand}`, 'success');
+      return { issueType: matchedCommand, success: true };
+    }
+
+    log(`Could not parse classification for issue #${issueNumber}, defaulting to /feature`, 'error');
+    return { issueType: '/feature', success: false };
+  } catch (error) {
+    log(`Error classifying issue #${issueNumber}: ${error}`, 'error');
+    return { issueType: '/feature', success: false };
+  }
+}
+
+/**
+ * Determines which workflow script to use based on issue type.
+ *
+ * - /feature and /chore use adwPlanBuildTest.tsx (includes Test phase)
+ * - /bug and /pr_review use adwPlanBuild.tsx (no Test phase)
+ *
+ * @param issueType - The classified issue type
+ * @returns The workflow script path to spawn
+ */
+export function getWorkflowScript(issueType: IssueClassSlashCommand): string {
+  switch (issueType) {
+    case '/feature':
+    case '/chore':
+      return 'adws/adwPlanBuildTest.tsx';
+    case '/bug':
+    case '/pr_review':
+      return 'adws/adwPlanBuild.tsx';
+    default:
+      // Default to test workflow for safety
+      return 'adws/adwPlanBuildTest.tsx';
+  }
+}

--- a/adws/triggers/trigger_cron.ts
+++ b/adws/triggers/trigger_cron.ts
@@ -8,6 +8,7 @@
 import { execSync, spawn } from 'child_process';
 import { log } from '../core';
 import { getRepoInfo, fetchPRList, hasUnaddressedComments } from '../github';
+import { classifyIssueForTrigger, getWorkflowScript } from './issueClassifier';
 
 const POLL_INTERVAL_MS = 20_000;
 const PR_POLL_INTERVAL_MS = 60_000;
@@ -42,7 +43,7 @@ function isQualifyingIssue(issue: RawIssue): boolean {
   return /adw/i.test(latestComment.body);
 }
 
-function checkAndTrigger(): void {
+async function checkAndTrigger(): Promise<void> {
   log('Polling for new issues...');
   const issues = fetchOpenIssues();
   const qualifying = issues.filter(
@@ -51,9 +52,17 @@ function checkAndTrigger(): void {
 
   for (const issue of qualifying) {
     processedIssues.add(issue.number);
-    log(`Triggering ADW workflow for issue #${issue.number}`, 'success');
 
-    const child = spawn('npx', ['tsx', 'adws/adwPlanBuild.tsx', String(issue.number)], {
+    // Classify the issue to determine which workflow to spawn
+    const classification = await classifyIssueForTrigger(issue.number);
+    const workflowScript = getWorkflowScript(classification.issueType);
+
+    log(
+      `Triggering ADW workflow for issue #${issue.number} (${classification.issueType} -> ${workflowScript})`,
+      'success'
+    );
+
+    const child = spawn('npx', ['tsx', workflowScript, String(issue.number)], {
       detached: true,
       stdio: 'ignore',
     });
@@ -90,7 +99,7 @@ function checkPRsForReviewComments(): void {
 }
 
 log('CRON trigger started');
-checkAndTrigger();
-setInterval(checkAndTrigger, POLL_INTERVAL_MS);
+void checkAndTrigger();
+setInterval(() => void checkAndTrigger(), POLL_INTERVAL_MS);
 checkPRsForReviewComments();
 setInterval(checkPRsForReviewComments, PR_POLL_INTERVAL_MS);

--- a/adws/triggers/trigger_webhook.ts
+++ b/adws/triggers/trigger_webhook.ts
@@ -14,6 +14,7 @@ import * as path from 'path';
 import { spawn } from 'child_process';
 import { log, PullRequestWebhookPayload } from '../core';
 import { closeIssue, formatIssueClosureComment } from '../github/githubApi';
+import { classifyIssueForTrigger, getWorkflowScript } from './issueClassifier';
 
 const port = parseInt(process.env.PORT || '8001', 10);
 
@@ -193,9 +194,25 @@ const server = http.createServer((req, res) => {
       return;
     }
 
-    log(`New issue #${issueNumber} detected, triggering ADW workflow`);
-    spawnDetached('npx', ['tsx', 'adws/adwPlanBuild.tsx', String(issueNumber)]);
-    jsonResponse(res, 200, { status: 'triggered', issue: issueNumber });
+    log(`New issue #${issueNumber} detected, classifying and triggering ADW workflow`);
+
+    // Classify the issue and spawn the appropriate workflow asynchronously
+    // Respond quickly to avoid GitHub timeout
+    classifyIssueForTrigger(issueNumber)
+      .then((classification) => {
+        const workflowScript = getWorkflowScript(classification.issueType);
+        log(
+          `Issue #${issueNumber} classified as ${classification.issueType}, spawning ${workflowScript}`,
+          'success'
+        );
+        spawnDetached('npx', ['tsx', workflowScript, String(issueNumber)]);
+      })
+      .catch((error) => {
+        log(`Error classifying issue #${issueNumber}: ${error}, defaulting to adwPlanBuildTest.tsx`, 'error');
+        spawnDetached('npx', ['tsx', 'adws/adwPlanBuildTest.tsx', String(issueNumber)]);
+      });
+
+    jsonResponse(res, 200, { status: 'processing', issue: issueNumber });
   });
 });
 

--- a/specs/issue-40-plan.md
+++ b/specs/issue-40-plan.md
@@ -1,0 +1,90 @@
+# Chore: Update triggers to use adwPlanBuildTest for features and chores
+
+## Chore Description
+The ADW (AI Developer Workflow) triggers currently spawn `adwPlanBuild.tsx` for all qualifying issues. This workflow only runs the Plan and Build phases. The chore requires updating the triggers to use `adwPlanBuildTest.tsx` (which includes a Test phase) for issues classified as `feature` or `chore`, while keeping `adwPlanBuild.tsx` for bugs.
+
+Additionally, the classification process in `classify_issue.md` needs to be updated to only classify an issue as `chore` if there is a low likelihood of additional tests being required (e.g., documentation updates, configuration changes, dependency updates).
+
+## Relevant Files
+Use these files to resolve the chore:
+
+- `adws/triggers/trigger_cron.ts` - CRON trigger that polls for issues and spawns workflows. Currently spawns `adwPlanBuild.tsx` at line 56. Needs to perform classification and spawn the appropriate workflow.
+- `adws/triggers/trigger_webhook.ts` - Webhook trigger that receives GitHub events and spawns workflows. Currently spawns `adwPlanBuild.tsx` at line 197. Needs to perform classification and spawn the appropriate workflow.
+- `.claude/commands/classify_issue.md` - The classification prompt used by the haiku model to classify issues. Needs updated criteria for chore classification.
+- `adws/github/githubApi.ts` - Contains `fetchGitHubIssue` function needed to get issue details for classification.
+- `adws/agents/claudeAgent.ts` - Contains `runClaudeAgentWithCommand` function for running the classifier agent.
+- `adws/core/dataTypes.ts` - Contains `IssueClassSlashCommand` type definition.
+- `adws/core/index.ts` - Core module exports for utility functions.
+
+### New Files
+- `adws/triggers/issueClassifier.ts` - New helper module to extract classification logic for use in triggers, avoiding code duplication between the two triggers.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### Step 1: Create the Issue Classifier Helper Module
+Create a new file `adws/triggers/issueClassifier.ts` that provides a lightweight classification function for use in triggers:
+
+- Import necessary dependencies from `../github/githubApi.ts` and `../agents/claudeAgent.ts`
+- Create an interface `IssueClassificationResult` with fields: `issueType: IssueClassSlashCommand`, `success: boolean`
+- Create function `classifyIssueForTrigger(issueNumber: number): Promise<IssueClassificationResult>` that:
+  - Fetches the issue details using `fetchGitHubIssue`
+  - Runs the classifier agent using `runClaudeAgentWithCommand` with the `/classify_issue` command
+  - Parses the result and returns the issue type
+  - Defaults to `/feature` on failure (to ensure the test phase runs for unknown issues)
+- Create helper function `getWorkflowScript(issueType: IssueClassSlashCommand): string` that:
+  - Returns `'adws/adwPlanBuildTest.tsx'` for `/feature` and `/chore`
+  - Returns `'adws/adwPlanBuild.tsx'` for `/bug` and `/pr_review`
+- Export both functions
+
+### Step 2: Update trigger_cron.ts
+Modify the CRON trigger to use classification before spawning workflows:
+
+- Add import for `classifyIssueForTrigger` and `getWorkflowScript` from `./issueClassifier`
+- Update the `checkAndTrigger` function to be async
+- In the loop over qualifying issues:
+  - Call `classifyIssueForTrigger(issue.number)` to get the issue classification
+  - Call `getWorkflowScript(issueType)` to determine which workflow script to use
+  - Update the spawn call at line 56 to use the determined workflow script instead of hardcoded `'adws/adwPlanBuild.tsx'`
+  - Log the classification result and workflow being used
+
+### Step 3: Update trigger_webhook.ts
+Modify the webhook trigger to use classification before spawning workflows:
+
+- Add import for `classifyIssueForTrigger` and `getWorkflowScript` from `./issueClassifier`
+- Update the issue event handler section (around line 196-198):
+  - Make the handler async for the issues event
+  - Call `classifyIssueForTrigger(issueNumber)` to get the issue classification
+  - Call `getWorkflowScript(issueType)` to determine which workflow script to use
+  - Update the `spawnDetached` call at line 197 to use the determined workflow script
+  - Log the classification result and workflow being used
+
+### Step 4: Update classify_issue.md Classification Criteria
+Update the chore classification criteria to be more specific:
+
+- Update the `/chore` command mapping entry to include specific criteria:
+  - Documentation-only changes (README, docs, comments)
+  - Configuration file updates (tsconfig, eslint, prettier configs)
+  - Dependency version updates
+  - CI/CD pipeline changes
+  - Code style/formatting changes
+  - Refactoring with no functional changes
+  - File/folder reorganization
+- Add explicit note that if the change might require new tests or modifications to existing tests, it should be classified as `/feature` instead
+- Add explicit note that bug fixes should use `/bug`, not `/chore`
+
+### Step 5: Run Validation Commands
+Run all validation commands to ensure the chore is complete with zero regressions.
+
+## Validation Commands
+Execute every command to validate the chore is complete with zero regressions.
+
+- `npm run lint` - Run linter to check for code quality issues
+- `npm run build` - Build the application to verify no build errors
+- `npm test` - Run tests to validate the chore is complete with zero regressions
+
+## Notes
+- The classification happens twice in the workflow: once in the trigger (to decide which workflow to spawn) and once in `adwPlan.tsx` (for branch naming and other purposes). This is acceptable duplication since it ensures the triggers can make informed decisions without modifying the existing workflow structure.
+- The classifier uses the `haiku` model for fast, cost-effective classification as established in the existing `adwPlan.tsx` implementation.
+- Defaulting to `/feature` on classification failure ensures the test phase is included for uncertain cases, which is the safer default.
+- The PR review workflow (`/pr_review`) continues to use `adwPlanBuild.tsx` since PR reviews address existing code changes that have already been tested.


### PR DESCRIPTION
## Summary
Implements #40 - Update triggers to use adwPlanBuildTest for bugs and features

## Implementation Plan


## Changes Made
## Summary

Implementation complete for GitHub Issue #40. Here's what was done:

- **Created `adws/triggers/issueClassifier.ts`** - New helper module with:
  - `classifyIssueForTrigger()` function that fetches issue details and runs the haiku classifier
  - `getWorkflowScript()` helper that routes `/feature` and `/chore` to `adwPlanBuildTest.tsx` (with Test phase) and `/bug` and `/pr_review` to `adwPlanBuild.tsx`
  - Defaults to `/feature` on classification failure to ensure tests run for unknown issues

- **Updated `adws/triggers/trigger_cron.ts`** - Modified to:
  - Import the new classifier functions
  - Make `checkAndTrigger()` async
  - Classify each issue before spawning the appropriate workflow

- **Updated `adws/triggers/trigger_webhook.ts`** - Modified to:
  - Import the new classifier functions
  - Classify issues asynchronously before spawning workflows
  - Return `processing` status immediately to avoid GitHub timeout

- **Updated `.claude/commands/classify_issue.md`** - Enhanced chore criteria:
  - Added specific examples (docs, configs, deps, CI/CD, formatting, refactoring)
  - Added explicit guidance that changes requiring tests should be `/feature`
  - Clarified that bug fixes should use `/bug`, not `/chore`

**Validation:** All checks passed (lint, build, 60 tests)

**Files changed:**
```
.claude/commands/classify_issue.md | 14 +++++++++++---
adws/triggers/trigger_cron.ts      | 19 ++++++++++++++-----
adws/triggers/trigger_webhook.ts   | 23 ++++++++++++++++++++---
adws/triggers/issueClassifier.ts   | 89 ++++++++++++++++++++++++++++++ (new file)
4 files changed, 134 insertions(+), 11 deletions(-)
```

## Testing
- [ ] All validation commands from the plan pass
- [ ] No regressions introduced
- [ ] Code follows project conventions

---
Generated by ADW Plan & Build workflow
