### PR TITLE
feat: Review plans created in wrong worktree (#59)

### DIFF
--- a/adws/__tests__/cwdPropagation.test.ts
+++ b/adws/__tests__/cwdPropagation.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+
+// Mock the child_process module
+vi.mock('child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+// Mock the config module
+vi.mock('../core/config', () => ({
+  CLAUDE_CODE_PATH: '/usr/local/bin/claude',
+  AGENTS_STATE_DIR: '/tmp/test-agents',
+}));
+
+// Import after mocks are set up
+import { spawn } from 'child_process';
+import { runClaudeAgent, runClaudeAgentWithCommand } from '../agents/claudeAgent';
+import { runTestAgent, runE2ETestAgent, runResolveTestAgent, runResolveE2ETestAgent } from '../agents/testAgent';
+import { TestResult, E2ETestResult } from '../agents/testAgent';
+
+// Generate a unique test directory
+const uniqueTestDir = `/tmp/test-cwd-${Buffer.from(__dirname).toString('base64').replace(/[/+=]/g, '').slice(0, 16)}`;
+
+describe('cwd propagation', () => {
+  const testLogsDir = `${uniqueTestDir}/test-logs`;
+  const customCwd = '/custom/working/directory';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    if (fs.existsSync(uniqueTestDir)) {
+      fs.rmSync(uniqueTestDir, { recursive: true, force: true });
+    }
+    fs.mkdirSync(testLogsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(uniqueTestDir)) {
+      fs.rmSync(uniqueTestDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('runClaudeAgent', () => {
+    it('uses process.cwd() when cwd is not provided', async () => {
+      const mockSpawn = createMockSpawn({ result: 'Success' });
+      (spawn as unknown as ReturnType<typeof vi.fn>).mockImplementation(mockSpawn);
+
+      await runClaudeAgent('test prompt', 'Test Agent', `${testLogsDir}/test.jsonl`);
+
+      expect(spawn).toHaveBeenCalledWith(
+        '/usr/local/bin/claude',
+        expect.any(Array),
+        expect.objectContaining({
+          cwd: process.cwd(),
+        })
+      );
+    });
+
+    it('uses provided cwd when specified', async () => {
+      const mockSpawn = createMockSpawn({ result: 'Success' });
+      (spawn as unknown as ReturnType<typeof vi.fn>).mockImplementation(mockSpawn);
+
+      await runClaudeAgent('test prompt', 'Test Agent', `${testLogsDir}/test.jsonl`, 'sonnet', undefined, undefined, customCwd);
+
+      expect(spawn).toHaveBeenCalledWith(
+        '/usr/local/bin/claude',
+        expect.any(Array),
+        expect.objectContaining({
+          cwd: customCwd,
+        })
+      );
+    });
+  });
+
+  describe('runClaudeAgentWithCommand', () => {
+    it('uses process.cwd() when cwd is not provided', async () => {
+      const mockSpawn = createMockSpawn({ result: 'Success' });
+      (spawn as unknown as ReturnType<typeof vi.fn>).mockImplementation(mockSpawn);
+
+      await runClaudeAgentWithCommand('/test', 'args', 'Test Agent', `${testLogsDir}/test.jsonl`);
+
+      expect(spawn).toHaveBeenCalledWith(
+        '/usr/local/bin/claude',
+        expect.any(Array),
+        expect.objectContaining({
+          cwd: process.cwd(),
+        })
+      );
+    });
+
+    it('uses provided cwd when specified', async () => {
+      const mockSpawn = createMockSpawn({ result: 'Success' });
+      (spawn as unknown as ReturnType<typeof vi.fn>).mockImplementation(mockSpawn);
+
+      await runClaudeAgentWithCommand('/test', 'args', 'Test Agent', `${testLogsDir}/test.jsonl`, 'sonnet', undefined, undefined, customCwd);
+
+      expect(spawn).toHaveBeenCalledWith(
+        '/usr/local/bin/claude',
+        expect.any(Array),
+        expect.objectContaining({
+          cwd: customCwd,
+        })
+      );
+    });
+  });
+
+  describe('runTestAgent', () => {
+    it('passes cwd to spawn when provided', async () => {
+      const testResults: TestResult[] = [
+        { test_name: 'linting', passed: true, execution_command: 'npm run lint', test_purpose: 'Check linting' },
+      ];
+      const mockSpawn = createMockSpawn({ result: JSON.stringify(testResults) });
+      (spawn as unknown as ReturnType<typeof vi.fn>).mockImplementation(mockSpawn);
+
+      await runTestAgent(testLogsDir, undefined, customCwd);
+
+      expect(spawn).toHaveBeenCalledWith(
+        '/usr/local/bin/claude',
+        expect.any(Array),
+        expect.objectContaining({
+          cwd: customCwd,
+        })
+      );
+    });
+  });
+
+  describe('runE2ETestAgent', () => {
+    it('passes cwd to spawn when provided', async () => {
+      const e2eResult: E2ETestResult = {
+        test_name: 'Login Test',
+        status: 'passed',
+        screenshots: [],
+        error: null,
+      };
+      const mockSpawn = createMockSpawn({ result: JSON.stringify(e2eResult) });
+      (spawn as unknown as ReturnType<typeof vi.fn>).mockImplementation(mockSpawn);
+
+      await runE2ETestAgent('/path/to/test.md', testLogsDir, undefined, customCwd);
+
+      expect(spawn).toHaveBeenCalledWith(
+        '/usr/local/bin/claude',
+        expect.any(Array),
+        expect.objectContaining({
+          cwd: customCwd,
+        })
+      );
+    });
+  });
+
+  describe('runResolveTestAgent', () => {
+    it('passes cwd to spawn when provided', async () => {
+      const mockSpawn = createMockSpawn({ result: 'Fixed' });
+      (spawn as unknown as ReturnType<typeof vi.fn>).mockImplementation(mockSpawn);
+
+      const failedTest: TestResult = {
+        test_name: 'build',
+        passed: false,
+        execution_command: 'npm run build',
+        test_purpose: 'Build app',
+        error: 'Type error',
+      };
+
+      await runResolveTestAgent(failedTest, testLogsDir, undefined, customCwd);
+
+      expect(spawn).toHaveBeenCalledWith(
+        '/usr/local/bin/claude',
+        expect.any(Array),
+        expect.objectContaining({
+          cwd: customCwd,
+        })
+      );
+    });
+  });
+
+  describe('runResolveE2ETestAgent', () => {
+    it('passes cwd to spawn when provided', async () => {
+      const mockSpawn = createMockSpawn({ result: 'Fixed' });
+      (spawn as unknown as ReturnType<typeof vi.fn>).mockImplementation(mockSpawn);
+
+      const failedE2ETest: E2ETestResult = {
+        test_name: 'Login Test',
+        status: 'failed',
+        screenshots: [],
+        error: 'Element not found',
+      };
+
+      await runResolveE2ETestAgent(failedE2ETest, testLogsDir, undefined, customCwd);
+
+      expect(spawn).toHaveBeenCalledWith(
+        '/usr/local/bin/claude',
+        expect.any(Array),
+        expect.objectContaining({
+          cwd: customCwd,
+        })
+      );
+    });
+  });
+});
+
+/**
+ * Creates a mock implementation of child_process.spawn that simulates
+ * the Claude CLI output format.
+ */
+function createMockSpawn(options: { result: string; exitCode?: number }) {
+  return () => {
+    const { result, exitCode = 0 } = options;
+
+    const mockStdout = {
+      on: vi.fn((event: string, callback: (data: Buffer) => void) => {
+        if (event === 'data') {
+          const jsonlOutput = JSON.stringify({
+            type: 'result',
+            subtype: 'success',
+            isError: false,
+            durationMs: 1000,
+            durationApiMs: 900,
+            numTurns: 1,
+            result,
+            sessionId: 'test-session-id',
+            totalCostUsd: 0.01,
+          });
+          setTimeout(() => callback(Buffer.from(jsonlOutput + '\n')), 10);
+        }
+      }),
+    };
+
+    const mockStderr = {
+      on: vi.fn(),
+    };
+
+    const mockProcess = {
+      stdout: mockStdout,
+      stderr: mockStderr,
+      stdin: {
+        write: vi.fn(),
+        end: vi.fn(),
+      },
+      on: vi.fn((event: string, callback: (code: number) => void) => {
+        if (event === 'close') {
+          setTimeout(() => callback(exitCode), 20);
+        }
+      }),
+    };
+
+    return mockProcess;
+  };
+}

--- a/adws/adwPlan.tsx
+++ b/adws/adwPlan.tsx
@@ -53,11 +53,17 @@ import {
 /**
  * Classifies a GitHub issue as feature, bug, or chore using the haiku model.
  * Uses the /classify_issue slash command from .claude/commands/classify_issue.md
+ *
+ * @param issue - GitHub issue to classify
+ * @param logsDir - Directory to write agent logs
+ * @param statePath - Optional path to agent's state directory for state tracking
+ * @param cwd - Optional working directory for the agent (defaults to process.cwd())
  */
 async function classifyIssue(
   issue: GitHubIssue,
   logsDir: string,
-  statePath?: string
+  statePath?: string,
+  cwd?: string
 ): Promise<IssueClassSlashCommand> {
   const labelsText = issue.labels.map(l => l.name).join(', ') || 'none';
 
@@ -74,7 +80,8 @@ ${issue.body || 'No description provided.'}`;
     outputFile,
     'haiku',
     undefined,
-    statePath
+    statePath,
+    cwd
   );
 
   if (!result.success) {
@@ -305,7 +312,7 @@ async function main(): Promise<void> {
         execution: AgentStateManager.createExecutionState('running'),
       });
 
-      issueType = await classifyIssue(issue, logsDir, classifierStatePath);
+      issueType = await classifyIssue(issue, logsDir, classifierStatePath, cwd || undefined);
       log(`Issue classified as: ${issueType}`, 'success');
       ctx.issueType = issueType;
 
@@ -366,7 +373,7 @@ async function main(): Promise<void> {
         execution: AgentStateManager.createExecutionState('running'),
       });
 
-      const planResult = await runPlanAgent(issue, logsDir, issueType, planAgentStatePath);
+      const planResult = await runPlanAgent(issue, logsDir, issueType, planAgentStatePath, cwd || undefined);
 
       if (!planResult.success) {
         AgentStateManager.writeState(planAgentStatePath, {

--- a/adws/adwPrReview.tsx
+++ b/adws/adwPrReview.tsx
@@ -135,7 +135,7 @@ async function main(): Promise<void> {
       metadata: { prNumber, reviewComments: unaddressedComments.length },
     });
 
-    const planResult = await runPrReviewPlanAgent(prDetails, unaddressedComments, existingPlanContent, logsDir, planAgentStatePath);
+    const planResult = await runPrReviewPlanAgent(prDetails, unaddressedComments, existingPlanContent, logsDir, planAgentStatePath, worktreePath);
 
     if (!planResult.success) {
       AgentStateManager.writeState(planAgentStatePath, {
@@ -173,7 +173,7 @@ async function main(): Promise<void> {
       }
     };
 
-    const buildResult = await runPrReviewBuildAgent(prDetails, planResult.output, logsDir, buildProgressCallback, buildAgentStatePath);
+    const buildResult = await runPrReviewBuildAgent(prDetails, planResult.output, logsDir, buildProgressCallback, buildAgentStatePath, worktreePath);
 
     if (!buildResult.success) {
       AgentStateManager.writeState(buildAgentStatePath, {
@@ -206,6 +206,7 @@ async function main(): Promise<void> {
       orchestratorStatePath,
       maxRetries: MAX_TEST_RETRY_ATTEMPTS,
       onTestFailed,
+      cwd: worktreePath,
     });
 
     if (!unitTestsResult.passed) {
@@ -232,6 +233,7 @@ async function main(): Promise<void> {
       orchestratorStatePath,
       maxRetries: MAX_TEST_RETRY_ATTEMPTS,
       onTestFailed,
+      cwd: worktreePath,
     });
 
     if (!e2eTestsResult.passed) {

--- a/adws/agents/buildAgent.ts
+++ b/adws/agents/buildAgent.ts
@@ -36,13 +36,21 @@ ${revisionPlan}`;
 /**
  * Runs the Build Agent to implement PR review changes.
  * Uses the /implement slash command with the revision plan as arguments.
+ *
+ * @param prDetails - PR details including number, title, branch, etc.
+ * @param revisionPlan - The revision plan to implement
+ * @param logsDir - Directory to write agent logs
+ * @param onProgress - Optional callback for progress updates
+ * @param statePath - Optional path to agent's state directory for state tracking
+ * @param cwd - Optional working directory for the agent (defaults to process.cwd())
  */
 export async function runPrReviewBuildAgent(
   prDetails: PRDetails,
   revisionPlan: string,
   logsDir: string,
   onProgress?: ProgressCallback,
-  statePath?: string
+  statePath?: string,
+  cwd?: string
 ): Promise<AgentResult> {
   const args = formatPrReviewImplementArgs(prDetails, revisionPlan);
   const outputFile = path.join(logsDir, 'pr-review-build-agent.jsonl');
@@ -53,19 +61,27 @@ export async function runPrReviewBuildAgent(
   log(`  Revision plan length: ${revisionPlan.length} characters`, 'info');
   log(`  Model: opus`, 'info');
 
-  return runClaudeAgentWithCommand('/implement', args, 'PR Review Build', outputFile, 'opus', onProgress, statePath);
+  return runClaudeAgentWithCommand('/implement', args, 'PR Review Build', outputFile, 'opus', onProgress, statePath, cwd);
 }
 
 /**
  * Runs the Build Agent to implement the solution.
  * Uses the /implement slash command with the plan content as arguments.
+ *
+ * @param issue - GitHub issue to implement
+ * @param logsDir - Directory to write agent logs
+ * @param planContent - The implementation plan content
+ * @param onProgress - Optional callback for progress updates
+ * @param statePath - Optional path to agent's state directory for state tracking
+ * @param cwd - Optional working directory for the agent (defaults to process.cwd())
  */
 export async function runBuildAgent(
   issue: GitHubIssue,
   logsDir: string,
   planContent: string,
   onProgress?: ProgressCallback,
-  statePath?: string
+  statePath?: string,
+  cwd?: string
 ): Promise<AgentResult> {
   const args = formatImplementArgs(issue, planContent);
   const outputFile = path.join(logsDir, 'build-agent.jsonl');
@@ -78,5 +94,5 @@ export async function runBuildAgent(
   log(`  Plan content length: ${planContent.length} characters`, 'info');
   log(`  Model: opus`, 'info');
 
-  return runClaudeAgentWithCommand('/implement', args, 'Build', outputFile, 'opus', onProgress, statePath);
+  return runClaudeAgentWithCommand('/implement', args, 'Build', outputFile, 'opus', onProgress, statePath, cwd);
 }

--- a/adws/agents/claudeAgent.ts
+++ b/adws/agents/claudeAgent.ts
@@ -139,6 +139,7 @@ function parseJsonlOutput(
  * @param model - The model to use (default: 'sonnet')
  * @param onProgress - Optional callback for progress updates
  * @param statePath - Optional path to agent's state directory for state tracking
+ * @param cwd - Optional working directory for the agent (defaults to process.cwd())
  */
 export async function runClaudeAgent(
   prompt: string,
@@ -146,7 +147,8 @@ export async function runClaudeAgent(
   outputFile: string,
   model: string = 'sonnet',
   onProgress?: ProgressCallback,
-  statePath?: string
+  statePath?: string,
+  cwd?: string
 ): Promise<AgentResult> {
   // Write initial state if state path provided
   if (statePath) {
@@ -170,7 +172,7 @@ export async function runClaudeAgent(
     log(`  Prompt length: ${prompt.length} characters`, 'info');
 
     const claude = spawn(CLAUDE_CODE_PATH, args, {
-      cwd: process.cwd(),
+      cwd: cwd || process.cwd(),
       env: { ...process.env }
     });
 
@@ -279,6 +281,7 @@ export async function runClaudeAgent(
  * @param model - The model to use ('opus', 'sonnet', 'haiku')
  * @param onProgress - Optional callback for progress updates
  * @param statePath - Optional path to agent's state directory for state tracking
+ * @param cwd - Optional working directory for the agent (defaults to process.cwd())
  */
 export async function runClaudeAgentWithCommand(
   command: string,
@@ -287,7 +290,8 @@ export async function runClaudeAgentWithCommand(
   outputFile: string,
   model: string = 'sonnet',
   onProgress?: ProgressCallback,
-  statePath?: string
+  statePath?: string,
+  cwd?: string
 ): Promise<AgentResult> {
   // Build the prompt as "command 'args'" for the CLI
   // The args are single-quoted to preserve formatting
@@ -317,7 +321,7 @@ export async function runClaudeAgentWithCommand(
     log(`  Args length: ${args.length} characters`, 'info');
 
     const claude = spawn(CLAUDE_CODE_PATH, cliArgs, {
-      cwd: process.cwd(),
+      cwd: cwd || process.cwd(),
       env: { ...process.env },
       stdio: ['ignore', 'pipe', 'pipe']
     });

--- a/adws/agents/planAgent.ts
+++ b/adws/agents/planAgent.ts
@@ -92,33 +92,48 @@ ${commentsSection}`;
 /**
  * Runs the Plan Agent to create a revision plan for PR review comments.
  * Uses the /pr_review slash command from .claude/commands/pr_review.md
+ *
+ * @param prDetails - PR details including number, title, branch, etc.
+ * @param comments - PR review comments to address
+ * @param existingPlanContent - Existing plan content or PR body for context
+ * @param logsDir - Directory to write agent logs
+ * @param statePath - Optional path to agent's state directory for state tracking
+ * @param cwd - Optional working directory for the agent (defaults to process.cwd())
  */
 export async function runPrReviewPlanAgent(
   prDetails: PRDetails,
   comments: PRReviewComment[],
   existingPlanContent: string,
   logsDir: string,
-  statePath?: string
+  statePath?: string,
+  cwd?: string
 ): Promise<AgentResult> {
   const args = formatPrReviewContextAsArgs(prDetails, comments, existingPlanContent);
   const outputFile = path.join(logsDir, 'pr-review-plan-agent.jsonl');
 
-  return runClaudeAgentWithCommand('/pr_review', args, 'PR Review Plan', outputFile, 'opus', undefined, statePath);
+  return runClaudeAgentWithCommand('/pr_review', args, 'PR Review Plan', outputFile, 'opus', undefined, statePath, cwd);
 }
 
 /**
  * Runs the Plan Agent to generate an implementation plan.
  * Uses the appropriate slash command (/feature, /bug, /chore, /pr_review) based on issue type.
+ *
+ * @param issue - GitHub issue to generate a plan for
+ * @param logsDir - Directory to write agent logs
+ * @param issueType - Type of issue (determines which slash command to use)
+ * @param statePath - Optional path to agent's state directory for state tracking
+ * @param cwd - Optional working directory for the agent (defaults to process.cwd())
  */
 export async function runPlanAgent(
   issue: GitHubIssue,
   logsDir: string,
   issueType: IssueClassSlashCommand = '/feature',
-  statePath?: string
+  statePath?: string,
+  cwd?: string
 ): Promise<AgentResult> {
   const args = formatIssueContextAsArgs(issue);
   const outputFile = path.join(logsDir, 'plan-agent.jsonl');
 
   // Use the issueType directly as the command (e.g., '/feature', '/bug', '/chore', '/pr_review')
-  return runClaudeAgentWithCommand(issueType, args, 'Plan', outputFile, 'opus', undefined, statePath);
+  return runClaudeAgentWithCommand(issueType, args, 'Plan', outputFile, 'opus', undefined, statePath, cwd);
 }

--- a/adws/agents/testAgent.ts
+++ b/adws/agents/testAgent.ts
@@ -112,10 +112,12 @@ function parseE2ETestResult(output: string): E2ETestResult | null {
  *
  * @param logsDir - Directory to write agent logs
  * @param statePath - Optional path to agent's state directory for state tracking
+ * @param cwd - Optional working directory for the agent (defaults to process.cwd())
  */
 export async function runTestAgent(
   logsDir: string,
-  statePath?: string
+  statePath?: string,
+  cwd?: string
 ): Promise<TestAgentResult> {
   const outputFile = path.join(logsDir, 'test-agent.jsonl');
 
@@ -127,7 +129,8 @@ export async function runTestAgent(
     outputFile,
     'sonnet',
     undefined,
-    statePath
+    statePath,
+    cwd
   );
 
   // Parse the test results from the output
@@ -150,11 +153,13 @@ export async function runTestAgent(
  * @param testFilePath - Path to the E2E test file
  * @param logsDir - Directory to write agent logs
  * @param statePath - Optional path to agent's state directory for state tracking
+ * @param cwd - Optional working directory for the agent (defaults to process.cwd())
  */
 export async function runE2ETestAgent(
   testFilePath: string,
   logsDir: string,
-  statePath?: string
+  statePath?: string,
+  cwd?: string
 ): Promise<E2ETestAgentResult> {
   const testName = path.basename(testFilePath, '.md');
   const outputFile = path.join(logsDir, `e2e-test-agent-${testName}.jsonl`);
@@ -167,7 +172,8 @@ export async function runE2ETestAgent(
     outputFile,
     'sonnet',
     undefined,
-    statePath
+    statePath,
+    cwd
   );
 
   // Parse the E2E test result from the output
@@ -193,11 +199,13 @@ export async function runE2ETestAgent(
  * @param failedTest - The test result that failed
  * @param logsDir - Directory to write agent logs
  * @param statePath - Optional path to agent's state directory for state tracking
+ * @param cwd - Optional working directory for the agent (defaults to process.cwd())
  */
 export async function runResolveTestAgent(
   failedTest: TestResult,
   logsDir: string,
-  statePath?: string
+  statePath?: string,
+  cwd?: string
 ): Promise<AgentResult> {
   const outputFile = path.join(logsDir, `resolve-test-${failedTest.test_name}.jsonl`);
 
@@ -211,7 +219,8 @@ export async function runResolveTestAgent(
     outputFile,
     'opus',
     undefined,
-    statePath
+    statePath,
+    cwd
   );
 }
 
@@ -222,11 +231,13 @@ export async function runResolveTestAgent(
  * @param failedE2ETest - The E2E test result that failed
  * @param logsDir - Directory to write agent logs
  * @param statePath - Optional path to agent's state directory for state tracking
+ * @param cwd - Optional working directory for the agent (defaults to process.cwd())
  */
 export async function runResolveE2ETestAgent(
   failedE2ETest: E2ETestResult,
   logsDir: string,
-  statePath?: string
+  statePath?: string,
+  cwd?: string
 ): Promise<AgentResult> {
   // Handle undefined or invalid test_name gracefully
   const rawTestName = failedE2ETest.test_name;
@@ -248,7 +259,8 @@ export async function runResolveE2ETestAgent(
     outputFile,
     'opus',
     undefined,
-    statePath
+    statePath,
+    cwd
   );
 }
 

--- a/adws/agents/testRetry.ts
+++ b/adws/agents/testRetry.ts
@@ -27,6 +27,8 @@ export interface TestRetryOptions {
   orchestratorStatePath: string;
   maxRetries: number;
   onTestFailed?: (attempt: number, maxAttempts: number) => void;
+  /** Optional working directory for agent operations (defaults to process.cwd()) */
+  cwd?: string;
 }
 
 function getAdwId(statePath: string): string {
@@ -38,14 +40,14 @@ function initState(statePath: string, agentName: AgentIdentifier): string {
 }
 
 export async function runUnitTestsWithRetry(opts: TestRetryOptions): Promise<TestRetryResult> {
-  const { logsDir, orchestratorStatePath: statePath, maxRetries, onTestFailed } = opts;
+  const { logsDir, orchestratorStatePath: statePath, maxRetries, onTestFailed, cwd } = opts;
   let retryCount = 0, costUsd = 0, lastFailedTests: TestResult[] = [];
 
   while (retryCount < maxRetries) {
     log(`Running unit tests (attempt ${retryCount + 1}/${maxRetries})...`, 'info');
     AgentStateManager.appendLog(statePath, `Unit test attempt ${retryCount + 1}/${maxRetries}`);
 
-    const testResult = await runTestAgent(logsDir, initState(statePath, 'test-agent'));
+    const testResult = await runTestAgent(logsDir, initState(statePath, 'test-agent'), cwd);
     costUsd += testResult.totalCostUsd || 0;
 
     if (!testResult.success) {
@@ -69,7 +71,7 @@ export async function runUnitTestsWithRetry(opts: TestRetryOptions): Promise<Tes
     for (const failedTest of lastFailedTests) {
       log(`Resolving: ${failedTest.test_name}`, 'info');
       AgentStateManager.appendLog(statePath, `Resolving failed test: ${failedTest.test_name}`);
-      const result = await runResolveTestAgent(failedTest, logsDir, initState(statePath, 'test-resolver-agent'));
+      const result = await runResolveTestAgent(failedTest, logsDir, initState(statePath, 'test-resolver-agent'), cwd);
       costUsd += result.totalCostUsd || 0;
       const msg = result.success ? 'Resolution attempted for' : 'Failed to resolve';
       log(`${msg}: ${failedTest.test_name}`, result.success ? 'success' : 'error');
@@ -84,8 +86,8 @@ export async function runUnitTestsWithRetry(opts: TestRetryOptions): Promise<Tes
 }
 
 export async function runE2ETestsWithRetry(opts: TestRetryOptions): Promise<TestRetryResult> {
-  const { logsDir, orchestratorStatePath: statePath, maxRetries, onTestFailed } = opts;
-  const e2eTestFiles = discoverE2ETestFiles();
+  const { logsDir, orchestratorStatePath: statePath, maxRetries, onTestFailed, cwd } = opts;
+  const e2eTestFiles = discoverE2ETestFiles(cwd);
   let costUsd = 0, totalRetries = 0;
 
   if (e2eTestFiles.length === 0) {
@@ -102,7 +104,7 @@ export async function runE2ETestsWithRetry(opts: TestRetryOptions): Promise<Test
   for (const testFile of e2eTestFiles) {
     log(`Running E2E test: ${testFile}`, 'info');
     AgentStateManager.appendLog(statePath, `Running E2E test: ${testFile}`);
-    const e2eResult = await runE2ETestAgent(testFile, logsDir, initState(statePath, 'test-agent'));
+    const e2eResult = await runE2ETestAgent(testFile, logsDir, initState(statePath, 'test-agent'), cwd);
     costUsd += e2eResult.totalCostUsd || 0;
 
     if (!e2eResult.passed && e2eResult.e2eResult) {
@@ -139,12 +141,12 @@ export async function runE2ETestsWithRetry(opts: TestRetryOptions): Promise<Test
       log(`Resolving E2E test: ${result.test_name ?? 'unknown'} (attempt ${retryCount + 1}/${maxRetries})`, 'info');
       AgentStateManager.appendLog(statePath, `Resolving E2E test: ${result.test_name ?? 'unknown'}`);
 
-      const resolveResult = await runResolveE2ETestAgent(result, logsDir, initState(statePath, 'test-resolver-agent'));
+      const resolveResult = await runResolveE2ETestAgent(result, logsDir, initState(statePath, 'test-resolver-agent'), cwd);
       costUsd += resolveResult.totalCostUsd || 0;
       totalRetries++;
 
       log(`Re-running E2E test: ${testFile}`, 'info');
-      const retryResult = await runE2ETestAgent(testFile, logsDir, initState(statePath, 'test-agent'));
+      const retryResult = await runE2ETestAgent(testFile, logsDir, initState(statePath, 'test-agent'), cwd);
       costUsd += retryResult.totalCostUsd || 0;
 
       if (retryResult.passed) {

--- a/specs/issue-59-plan.md
+++ b/specs/issue-59-plan.md
@@ -1,0 +1,128 @@
+# Bug: Review plans created in wrong worktree
+
+## Bug Description
+When the ADW PR Review workflow processes review comments, the Claude agent makes file modifications (like updating plan files) in the main worktree instead of the issue's worktree. This causes plan files and other changes to appear in the wrong directory, leading to unexpected behavior and potential conflicts when multiple PRs are being processed simultaneously.
+
+**Expected behavior:** When processing PR review comments, all file operations should occur within the worktree created for that PR branch.
+
+**Actual behavior:** File operations occur in `process.cwd()` (typically the main repository), regardless of which worktree was created for the PR.
+
+## Problem Statement
+The `runClaudeAgent` and `runClaudeAgentWithCommand` functions in `claudeAgent.ts` hardcode `process.cwd()` as the working directory when spawning the Claude process. Even though `adwPrReview.tsx` correctly creates a worktree via `ensureWorktree()`, this worktree path is never passed to the agent functions, causing the Claude agent to operate in the wrong directory.
+
+## Solution Statement
+Add an optional `cwd` parameter to the Claude agent runner functions and propagate this parameter through the agent function chain. Update `adwPrReview.tsx` to pass the worktree path to all agent invocations, ensuring all file operations occur in the correct worktree.
+
+## Steps to Reproduce
+1. Create a PR from a feature branch
+2. Add review comments to the PR
+3. Run `npx tsx adws/adwPrReview.tsx <pr-number>`
+4. Observe that any plan file modifications appear in the main worktree instead of the `.worktrees/<branch-name>/` directory
+
+## Root Cause Analysis
+The bug originates from two locations in `claudeAgent.ts`:
+
+1. **Line 172-175** in `runClaudeAgent`:
+   ```typescript
+   const claude = spawn(CLAUDE_CODE_PATH, args, {
+     cwd: process.cwd(),  // <-- Bug: hardcoded to current directory
+     env: { ...process.env }
+   });
+   ```
+
+2. **Line 319-323** in `runClaudeAgentWithCommand`:
+   ```typescript
+   const claude = spawn(CLAUDE_CODE_PATH, cliArgs, {
+     cwd: process.cwd(),  // <-- Bug: hardcoded to current directory
+     env: { ...process.env },
+     stdio: ['ignore', 'pipe', 'pipe']
+   });
+   ```
+
+In `adwPrReview.tsx`:
+- Line 106: `ensureWorktree(prDetails.headBranch)` correctly returns the worktree path
+- Lines 138, 176: `runPrReviewPlanAgent` and `runPrReviewBuildAgent` are called without passing the worktree path
+- The agent functions don't have parameters to accept a working directory
+
+## Relevant Files
+Use these files to fix the bug:
+
+- `adws/agents/claudeAgent.ts` - Core agent runner that spawns Claude processes. Contains the root cause where `process.cwd()` is hardcoded.
+- `adws/agents/planAgent.ts` - Plan agent functions that need to accept and pass through the `cwd` parameter.
+- `adws/agents/buildAgent.ts` - Build agent functions that need to accept and pass through the `cwd` parameter.
+- `adws/agents/testAgent.ts` - Test agent functions that need to accept and pass through the `cwd` parameter. Also contains `discoverE2ETestFiles` which uses `process.cwd()`.
+- `adws/agents/testRetry.ts` - Test retry logic that calls test agents and needs to pass through the `cwd` parameter.
+- `adws/agents/index.ts` - Agent exports, may need to update type exports.
+- `adws/adwPrReview.tsx` - PR review workflow that creates the worktree but doesn't pass it to agents.
+- `adws/adwPlan.tsx` - Plan workflow already has `--cwd` option pattern that can be referenced but also needs updating for agent calls.
+- `adws/__tests__/worktreeOperations.test.ts` - Existing worktree tests to verify behavior.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### Step 1: Update `claudeAgent.ts` to accept optional `cwd` parameter
+- Add optional `cwd?: string` parameter to `runClaudeAgent` function signature
+- Add optional `cwd?: string` parameter to `runClaudeAgentWithCommand` function signature
+- Replace `cwd: process.cwd()` with `cwd: cwd || process.cwd()` in both spawn calls
+- Update JSDoc comments to document the new parameter
+
+### Step 2: Update `planAgent.ts` to accept and pass `cwd` parameter
+- Add optional `cwd?: string` parameter to `runPrReviewPlanAgent` function signature
+- Add optional `cwd?: string` parameter to `runPlanAgent` function signature
+- Pass the `cwd` parameter to `runClaudeAgentWithCommand` calls
+- Update JSDoc comments to document the new parameter
+
+### Step 3: Update `buildAgent.ts` to accept and pass `cwd` parameter
+- Add optional `cwd?: string` parameter to `runPrReviewBuildAgent` function signature
+- Add optional `cwd?: string` parameter to `runBuildAgent` function signature
+- Pass the `cwd` parameter to `runClaudeAgentWithCommand` calls
+- Update JSDoc comments to document the new parameter
+
+### Step 4: Update `testAgent.ts` to accept and pass `cwd` parameter
+- Add optional `cwd?: string` parameter to `runTestAgent` function signature
+- Add optional `cwd?: string` parameter to `runE2ETestAgent` function signature
+- Add optional `cwd?: string` parameter to `runResolveTestAgent` function signature
+- Add optional `cwd?: string` parameter to `runResolveE2ETestAgent` function signature
+- Update `discoverE2ETestFiles` to use the `cwd` parameter (already has `baseDir` parameter, ensure it's used correctly)
+- Pass the `cwd` parameter to `runClaudeAgentWithCommand` calls
+- Update JSDoc comments to document the new parameter
+
+### Step 5: Update `testRetry.ts` to accept and pass `cwd` parameter
+- Add optional `cwd?: string` field to `TestRetryOptions` interface
+- Update `runUnitTestsWithRetry` to pass `cwd` to `runTestAgent` and `runResolveTestAgent`
+- Update `runE2ETestsWithRetry` to pass `cwd` to `discoverE2ETestFiles`, `runE2ETestAgent`, and `runResolveE2ETestAgent`
+
+### Step 6: Update `adwPrReview.tsx` to pass worktree path to all agents
+- Pass `worktreePath` to `runPrReviewPlanAgent` call on line 138
+- Pass `worktreePath` to `runPrReviewBuildAgent` call on line 176
+- Pass `worktreePath` to `runUnitTestsWithRetry` options
+- Pass `worktreePath` to `runE2ETestsWithRetry` options
+- The worktree path is already captured on line 106 via `ensureWorktree(prDetails.headBranch)`
+
+### Step 7: Update `adwPlan.tsx` to pass cwd to agent calls
+- Pass `cwd` parameter to `classifyIssue` call on line 308
+- Pass `cwd` parameter to `runPlanAgent` call on line 369
+- Update `classifyIssue` function to accept and pass `cwd` to `runClaudeAgentWithCommand`
+
+### Step 8: Write unit tests for cwd propagation
+- Add test case in `adws/__tests__/` to verify cwd is passed correctly to spawn
+- Test that agents use the provided cwd when specified
+- Test that agents fall back to `process.cwd()` when cwd is not provided
+
+### Step 9: Run validation commands
+- Run linter to check for code quality issues
+- Run build to verify no build errors
+- Run tests to validate the bug is fixed with zero regressions
+
+## Validation Commands
+Execute every command to validate the bug is fixed with zero regressions.
+
+- `npm run lint` - Run linter to check for code quality issues
+- `npm run build` - Build the application to verify no build errors
+- `npm test` - Run tests to validate the bug is fixed with zero regressions
+
+## Notes
+- The `adwPlan.tsx` file already has a `--cwd` CLI option pattern that shows awareness of working directory concerns, but the cwd is not propagated to agent functions
+- The `gitOperations.ts` functions like `commitChanges` and `createFeatureBranch` already accept an optional `cwd` parameter, providing a reference pattern for this fix
+- This bug affects all ADW workflows that use worktrees, not just PR review - the fix should benefit planning and build workflows as well
+- When testing, create a test worktree and verify that file operations occur in the worktree directory rather than the main repository


### PR DESCRIPTION
## Summary
Implements #59 - Review plans created in wrong worktree

## Implementation Plan


## Changes Made


## Testing
- [ ] All validation commands from the plan pass
- [ ] No regressions introduced
- [ ] Code follows project conventions

---
Generated by ADW Plan & Build workflow
