### PR TITLE
feat: replace timestamp from adw id (#121)

### DIFF
--- a/adws/__tests__/generateAdwId.test.ts
+++ b/adws/__tests__/generateAdwId.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { generateAdwId } from '../core/utils';
+import { extractAdwIdFromComment } from '../github/workflowCommentsBase';
+
+describe('generateAdwId', () => {
+  describe('with summary', () => {
+    it('produces adw-{slug}-{random} format', () => {
+      const id = generateAdwId('Fix login bug');
+      expect(id).toMatch(/^adw-fix-login-bug-[a-z0-9]{6}$/);
+    });
+
+    it('truncates summary portion to max 20 characters', () => {
+      const id = generateAdwId('This is a very long issue title that exceeds twenty characters');
+      const parts = id.split('-');
+      // Remove 'adw' prefix and last random suffix
+      const summaryPart = parts.slice(1, -1).join('-');
+      expect(summaryPart.length).toBeLessThanOrEqual(20);
+    });
+
+    it('removes trailing hyphen caused by truncation', () => {
+      // "replace timestamp from" slugifies to "replace-timestamp-from" (22 chars)
+      // Truncated to 20: "replace-timestamp-fr" — no trailing hyphen
+      // But "add-new-feature-for-" would have trailing hyphen at 20 chars
+      const id = generateAdwId('Add new feature for users and admins');
+      const parts = id.split('-');
+      const summaryPart = parts.slice(1, -1).join('-');
+      expect(summaryPart).not.toMatch(/-$/);
+    });
+
+    it('slugifies special characters', () => {
+      const id = generateAdwId("Fix bug: can't login!");
+      expect(id).toMatch(/^adw-fix-bug-can-t-login-[a-z0-9]{6}$/);
+    });
+
+    it('converts to lowercase', () => {
+      const id = generateAdwId('ADD NEW Feature');
+      expect(id).toMatch(/^adw-add-new-feature-[a-z0-9]{6}$/);
+    });
+
+    it('falls back to timestamp when summary produces empty slug', () => {
+      const id = generateAdwId('!!!@@@###');
+      expect(id).toMatch(/^adw-\d+-[a-z0-9]{6}$/);
+    });
+  });
+
+  describe('without summary', () => {
+    it('falls back to timestamp format when no summary provided', () => {
+      const id = generateAdwId();
+      expect(id).toMatch(/^adw-\d+-[a-z0-9]{6}$/);
+    });
+
+    it('falls back to timestamp format for empty string', () => {
+      const id = generateAdwId('');
+      expect(id).toMatch(/^adw-\d+-[a-z0-9]{6}$/);
+    });
+  });
+
+  describe('random suffix', () => {
+    it('always has 6 alphanumeric characters', () => {
+      const ids = Array.from({ length: 10 }, () => generateAdwId('test'));
+      ids.forEach((id) => {
+        const suffix = id.split('-').pop();
+        expect(suffix).toMatch(/^[a-z0-9]{6}$/);
+      });
+    });
+  });
+
+  describe('uniqueness', () => {
+    it('produces different IDs for same summary', () => {
+      const id1 = generateAdwId('Same summary');
+      const id2 = generateAdwId('Same summary');
+      expect(id1).not.toBe(id2);
+    });
+  });
+});
+
+describe('extractAdwIdFromComment', () => {
+  it('extracts old-format ADW ID (timestamp-based)', () => {
+    const body = '**ADW ID:** `adw-1770819277126-v2n6pm`';
+    expect(extractAdwIdFromComment(body)).toBe('adw-1770819277126-v2n6pm');
+  });
+
+  it('extracts new-format ADW ID (summary-based)', () => {
+    const body = '**ADW ID:** `adw-replace-timestamp-v2n6pm`';
+    expect(extractAdwIdFromComment(body)).toBe('adw-replace-timestamp-v2n6pm');
+  });
+
+  it('extracts short old-format ADW ID', () => {
+    const body = '**ADW ID:** `adw-123-abc`';
+    expect(extractAdwIdFromComment(body)).toBe('adw-123-abc');
+  });
+
+  it('returns null when no ADW ID is present', () => {
+    const body = 'Just a regular comment';
+    expect(extractAdwIdFromComment(body)).toBeNull();
+  });
+
+  it('returns null for incomplete ADW ID without backticks', () => {
+    const body = 'ADW ID: adw-123-abc';
+    expect(extractAdwIdFromComment(body)).toBeNull();
+  });
+});

--- a/adws/__tests__/workflowPhases.test.ts
+++ b/adws/__tests__/workflowPhases.test.ts
@@ -26,6 +26,7 @@ vi.mock('fs');
 vi.mock('../core', () => ({
   log: vi.fn(),
   ensureLogsDirectory: vi.fn().mockReturnValue('/mock/logs'),
+  generateAdwId: vi.fn().mockReturnValue('adw-test-issue-abc123'),
   commitPrefixMap: {
     '/feature': 'feat:',
     '/bug': 'fix:',
@@ -139,7 +140,7 @@ vi.mock('../triggers/issueClassifier', () => ({
 }));
 
 // Import mocked modules for assertions
-import { shouldExecuteStage, hasUncommittedChanges, getNextStage, AgentStateManager } from '../core';
+import { shouldExecuteStage, hasUncommittedChanges, getNextStage, AgentStateManager, generateAdwId } from '../core';
 import {
   fetchGitHubIssue,
   fetchPRDetails,
@@ -292,6 +293,13 @@ describe('initializeWorkflow', () => {
     await initializeWorkflow(1, 'test-id', 'plan-orchestrator');
 
     expect(hasUncommittedChanges).toHaveBeenCalled();
+  });
+
+  it('generates ADW ID from issue title when adwId is null', async () => {
+    const config = await initializeWorkflow(1, null, 'plan-orchestrator');
+
+    expect(generateAdwId).toHaveBeenCalledWith('Test issue');
+    expect(config.adwId).toBe('adw-test-issue-abc123');
   });
 });
 
@@ -659,6 +667,13 @@ describe('initializePRReviewWorkflow', () => {
       prNumber: 42,
       reviewComments: 1,
     }));
+  });
+
+  it('generates ADW ID from PR title when adwId is null', () => {
+    const config = initializePRReviewWorkflow(42, null);
+
+    expect(generateAdwId).toHaveBeenCalledWith('Test PR');
+    expect(config.adwId).toBe('adw-test-issue-abc123');
   });
 });
 

--- a/adws/adwBuild.tsx
+++ b/adws/adwBuild.tsx
@@ -146,7 +146,7 @@ async function main(): Promise<void> {
   log(`Fetched issue: ${issue.title}`, 'success');
 
   // Step 2: Determine ADW ID
-  const adwId = providedAdwId || generateAdwId();
+  const adwId = providedAdwId || generateAdwId(issue.title);
   const logsDir = ensureLogsDirectory(adwId);
   log(`ADW ID: ${adwId}`, 'info');
   log(`Logs: ${logsDir}`, 'info');

--- a/adws/adwPlan.tsx
+++ b/adws/adwPlan.tsx
@@ -15,7 +15,7 @@
  * - GITHUB_PAT: (Optional) GitHub Personal Access Token
  */
 
-import { generateAdwId, type IssueClassSlashCommand } from './core';
+import { type IssueClassSlashCommand } from './core';
 import {
   initializeWorkflow,
   executePlanPhase,
@@ -94,7 +94,7 @@ function parseArguments(args: string[]): {
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const { issueNumber, providedAdwId, cwd, providedIssueType } = parseArguments(args);
-  const adwId = providedAdwId || generateAdwId();
+  const adwId = providedAdwId || null;
 
   const config = await initializeWorkflow(issueNumber, adwId, 'plan-orchestrator', {
     cwd: cwd || undefined,

--- a/adws/adwPlanBuild.tsx
+++ b/adws/adwPlanBuild.tsx
@@ -17,7 +17,6 @@
  * - GITHUB_PAT: (Optional) GitHub Personal Access Token
  */
 
-import { generateAdwId } from './core';
 import {
   initializeWorkflow,
   executePlanPhase,
@@ -45,7 +44,7 @@ function printUsageAndExit(): never {
 /**
  * Parses and validates command line arguments.
  */
-function parseArguments(args: string[]): { issueNumber: number; adwId: string } {
+function parseArguments(args: string[]): { issueNumber: number; adwId: string | null } {
   if (args.length < 1) {
     printUsageAndExit();
   }
@@ -56,7 +55,7 @@ function parseArguments(args: string[]): { issueNumber: number; adwId: string } 
     process.exit(1);
   }
 
-  const adwId = args[1] || generateAdwId();
+  const adwId = args[1] || null;
 
   return { issueNumber, adwId };
 }

--- a/adws/adwPlanBuildTest.tsx
+++ b/adws/adwPlanBuildTest.tsx
@@ -19,7 +19,6 @@
  * - MAX_TEST_RETRY_ATTEMPTS: Maximum retry attempts for tests (default: 5)
  */
 
-import { generateAdwId } from './core';
 import {
   initializeWorkflow,
   executePlanPhase,
@@ -49,7 +48,7 @@ function printUsageAndExit(): never {
 /**
  * Parses and validates command line arguments.
  */
-function parseArguments(args: string[]): { issueNumber: number; adwId: string } {
+function parseArguments(args: string[]): { issueNumber: number; adwId: string | null } {
   if (args.length < 1) {
     printUsageAndExit();
   }
@@ -60,7 +59,7 @@ function parseArguments(args: string[]): { issueNumber: number; adwId: string } 
     process.exit(1);
   }
 
-  const adwId = args[1] || generateAdwId();
+  const adwId = args[1] || null;
 
   return { issueNumber, adwId };
 }

--- a/adws/adwPrReview.tsx
+++ b/adws/adwPrReview.tsx
@@ -16,7 +16,6 @@
  * - CLAUDE_CODE_PATH: Path to Claude CLI (default: /usr/local/bin/claude)
  */
 
-import { generateAdwId } from './core';
 import {
   initializePRReviewWorkflow,
   executePRReviewPlanPhase,
@@ -40,8 +39,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const adwId = generateAdwId();
-  const config = initializePRReviewWorkflow(prNumber, adwId);
+  const config = initializePRReviewWorkflow(prNumber, null);
 
   try {
     const { planOutput } = await executePRReviewPlanPhase(config);

--- a/adws/core/utils.ts
+++ b/adws/core/utils.ts
@@ -9,10 +9,18 @@ import { AgentIdentifier } from './dataTypes';
 
 /**
  * Generates a unique ADW session identifier.
- * Format: adw-{timestamp}-{random}
+ * When a summary is provided, format: adw-{slugified-summary}-{random}
+ * When no summary is provided, falls back to: adw-{timestamp}-{random}
  */
-export function generateAdwId(): string {
-  return `adw-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
+export function generateAdwId(summary?: string): string {
+  const random = Math.random().toString(36).substring(2, 8);
+  if (summary) {
+    const slug = slugify(summary).substring(0, 20).replace(/-$/, '');
+    if (slug) {
+      return `adw-${slug}-${random}`;
+    }
+  }
+  return `adw-${Date.now()}-${random}`;
 }
 
 /**

--- a/adws/github/workflowCommentsBase.ts
+++ b/adws/github/workflowCommentsBase.ts
@@ -70,9 +70,9 @@ export function parseWorkflowStageFromComment(commentBody: string): WorkflowStag
   return STAGE_HEADER_MAP[headerMatch[1]] || null;
 }
 
-/** Extracts the ADW ID from a comment body. Pattern: `adw-{timestamp}-{random}` */
+/** Extracts the ADW ID from a comment body. Matches both old format `adw-{timestamp}-{random}` and new format `adw-{slug}-{random}`. */
 export function extractAdwIdFromComment(commentBody: string): string | null {
-  const match = commentBody.match(/`(adw-\d+-[a-z0-9]+)`/);
+  const match = commentBody.match(/`(adw-[a-z0-9][a-z0-9-]*[a-z0-9])`/);
   return match ? match[1] : null;
 }
 

--- a/adws/workflowPhases.ts
+++ b/adws/workflowPhases.ts
@@ -14,6 +14,7 @@ import * as path from 'path';
 import {
   log,
   ensureLogsDirectory,
+  generateAdwId,
   type IssueClassSlashCommand,
   type GitHubIssue,
   type PRDetails,
@@ -87,20 +88,23 @@ export interface WorkflowConfig {
  */
 export async function initializeWorkflow(
   issueNumber: number,
-  adwId: string,
+  adwId: string | null,
   orchestratorName: AgentIdentifier,
   options?: { cwd?: string; issueType?: IssueClassSlashCommand }
 ): Promise<WorkflowConfig> {
-  log('===================================', 'info');
-  log(`${orchestratorName}`, 'info');
-  log(`Issue: #${issueNumber}`, 'info');
-  log(`ADW ID: ${adwId}`, 'info');
-  log('===================================', 'info');
-
   // Fetch issue
   log('Fetching GitHub issue...', 'info');
   const issue = await fetchGitHubIssue(issueNumber);
   log(`Fetched issue: ${issue.title}`, 'success');
+
+  // Resolve ADW ID: use provided or generate from issue title
+  const resolvedAdwId = adwId ?? generateAdwId(issue.title);
+
+  log('===================================', 'info');
+  log(`${orchestratorName}`, 'info');
+  log(`Issue: #${issueNumber}`, 'info');
+  log(`ADW ID: ${resolvedAdwId}`, 'info');
+  log('===================================', 'info');
 
   // Classify issue type
   let issueType: IssueClassSlashCommand;
@@ -115,7 +119,7 @@ export async function initializeWorkflow(
   }
 
   // Initialize logs early so agents can use the directory
-  const logsDir = ensureLogsDirectory(adwId);
+  const logsDir = ensureLogsDirectory(resolvedAdwId);
 
   // Setup worktree with branch sync
   const defaultBranch = getDefaultBranch();
@@ -128,7 +132,7 @@ export async function initializeWorkflow(
   } else {
     // Use agent to generate branch name only (no git operations)
     const branchResult = await runGenerateBranchNameAgent(
-      issueType, adwId, issue, logsDir
+      issueType, resolvedAdwId, issue, logsDir
     );
     branchName = branchResult.branchName;
     log(`Branch name generated: ${branchName}`, 'success');
@@ -148,12 +152,12 @@ export async function initializeWorkflow(
     }
     log(`Worktree path: ${worktreePath}`, 'info');
   }
-  const orchestratorStatePath = AgentStateManager.initializeState(adwId, orchestratorName);
+  const orchestratorStatePath = AgentStateManager.initializeState(resolvedAdwId, orchestratorName);
   log(`State: ${orchestratorStatePath}`, 'info');
   log(`Logs: ${logsDir}`, 'info');
 
   const initialState: Partial<AgentState> = {
-    adwId,
+    adwId: resolvedAdwId,
     issueNumber,
     agentName: orchestratorName,
     execution: AgentStateManager.createExecutionState('running'),
@@ -167,7 +171,7 @@ export async function initializeWorkflow(
   // Initialize workflow context
   const ctx: WorkflowContext = {
     issueNumber,
-    adwId,
+    adwId: resolvedAdwId,
     issueType,
   };
 
@@ -192,7 +196,7 @@ export async function initializeWorkflow(
 
   return {
     issueNumber,
-    adwId,
+    adwId: resolvedAdwId,
     issue,
     issueType,
     worktreePath,
@@ -576,15 +580,18 @@ export interface PRReviewWorkflowConfig {
  * Initializes a PR review workflow: fetches PR details, checks for unaddressed
  * comments, sets up worktree, and initializes state.
  */
-export function initializePRReviewWorkflow(prNumber: number, adwId: string): PRReviewWorkflowConfig {
+export function initializePRReviewWorkflow(prNumber: number, adwId: string | null): PRReviewWorkflowConfig {
+  const prDetails = fetchPRDetails(prNumber);
+  log(`Fetched PR: ${prDetails.title}`, 'success');
+
+  // Resolve ADW ID: use provided or generate from PR title
+  const resolvedAdwId = adwId ?? generateAdwId(prDetails.title);
+
   log('===================================', 'info');
   log('PR Review Orchestrator', 'info');
   log(`PR: #${prNumber}`, 'info');
-  log(`ADW ID: ${adwId}`, 'info');
+  log(`ADW ID: ${resolvedAdwId}`, 'info');
   log('===================================', 'info');
-
-  const prDetails = fetchPRDetails(prNumber);
-  log(`Fetched PR: ${prDetails.title}`, 'success');
 
   if (prDetails.state === 'CLOSED' || prDetails.state === 'MERGED') {
     log(`PR #${prNumber} is ${prDetails.state}, skipping`, 'info');
@@ -600,13 +607,13 @@ export function initializePRReviewWorkflow(prNumber: number, adwId: string): PRR
 
   log(`Found ${unaddressedComments.length} unaddressed review comment(s)`, 'info');
 
-  const logsDir = ensureLogsDirectory(adwId);
+  const logsDir = ensureLogsDirectory(resolvedAdwId);
   const issueNumber = prDetails.issueNumber || 0;
-  const orchestratorStatePath = AgentStateManager.initializeState(adwId, 'pr-review-orchestrator');
+  const orchestratorStatePath = AgentStateManager.initializeState(resolvedAdwId, 'pr-review-orchestrator');
   log(`State: ${orchestratorStatePath}`, 'info');
 
   const initialState: Partial<AgentState> = {
-    adwId,
+    adwId: resolvedAdwId,
     issueNumber,
     branchName: prDetails.headBranch,
     agentName: 'pr-review-orchestrator',
@@ -618,7 +625,7 @@ export function initializePRReviewWorkflow(prNumber: number, adwId: string): PRR
 
   const ctx: PRReviewWorkflowContext = {
     issueNumber,
-    adwId,
+    adwId: resolvedAdwId,
     prNumber,
     reviewComments: unaddressedComments.length,
     branchName: prDetails.headBranch,
@@ -632,7 +639,7 @@ export function initializePRReviewWorkflow(prNumber: number, adwId: string): PRR
   return {
     prNumber,
     issueNumber,
-    adwId,
+    adwId: resolvedAdwId,
     prDetails,
     unaddressedComments,
     worktreePath,

--- a/specs/issue-121-plan.md
+++ b/specs/issue-121-plan.md
@@ -1,0 +1,169 @@
+# Feature: Replace Timestamp with Summary in ADW ID
+
+## Feature Description
+Currently, ADW (AI Developer Workflow) session identifiers are generated using the format `adw-{timestamp}-{random}` (e.g., `adw-1770819277126-v2n6pm`). The timestamp portion is a Unix millisecond value that is not human-readable. This feature replaces the timestamp with a short, slugified summary of the issue title (max 20 characters), producing IDs like `adw-replace-timestamp-v2n6pm`. This makes ADW IDs immediately meaningful when seen in GitHub comments, branch names, log directories, and state directories.
+
+## User Story
+As a developer reviewing ADW workflow output
+I want ADW IDs to contain a readable summary instead of a timestamp
+So that I can quickly identify which issue an ADW session relates to without cross-referencing
+
+## Problem Statement
+ADW IDs like `adw-1770819277126-v2n6pm` contain a Unix timestamp that conveys no meaningful information to a human reader. When these IDs appear in GitHub issue comments, branch names, log directories, and state directories, developers cannot tell at a glance which issue or workflow the ID belongs to.
+
+## Solution Statement
+Modify the `generateAdwId()` function to accept an optional `summary` parameter (the issue title or PR title). When provided, the timestamp is replaced with a slugified, truncated (max 20 chars) version of the summary. When no summary is available (e.g., standalone test runner), the function falls back to the existing timestamp-based format for backwards compatibility. Update all callers to pass the issue/PR title, and update the `extractAdwIdFromComment()` regex to match both old and new formats.
+
+## Relevant Files
+Use these files to implement the feature:
+
+### Core ADW ID Generation
+- `adws/core/utils.ts` — Contains `generateAdwId()` function (line 14) and `slugify()` helper (line 22). Primary modification target.
+- `adws/core/index.ts` — Re-exports `generateAdwId` from utils. No changes needed.
+
+### Comment Extraction (Regex Update)
+- `adws/github/workflowCommentsBase.ts` — Contains `extractAdwIdFromComment()` (line 74) with regex `adw-\d+-[a-z0-9]+` that must be updated to match the new format.
+
+### Workflow Initialization (Caller Updates)
+- `adws/workflowPhases.ts` — Contains `initializeWorkflow()` (line 88) and `initializePRReviewWorkflow()` (line 579). These functions fetch the issue/PR and should generate the ADW ID with the title context.
+- `adws/adwPlan.tsx` — Calls `generateAdwId()` at line 97. Needs to pass `null` for auto-generation inside `initializeWorkflow`.
+- `adws/adwBuild.tsx` — Calls `generateAdwId()` at line 149. Fetches its own issue, so pass issue title directly.
+- `adws/adwPlanBuild.tsx` — Calls `generateAdwId()` at line 59. Needs to pass `null` for auto-generation inside `initializeWorkflow`.
+- `adws/adwPlanBuildTest.tsx` — Calls `generateAdwId()` at line 63. Needs to pass `null` for auto-generation inside `initializeWorkflow`.
+- `adws/adwPrReview.tsx` — Calls `generateAdwId()` at line 43. Needs to pass `null` for auto-generation inside `initializePRReviewWorkflow`.
+- `adws/adwTest.tsx` — Calls `generateAdwId()` at line 62. No issue context available; keep timestamp fallback.
+
+### Tests
+- `adws/__tests__/commentFiltering.test.ts` — Contains test data with old-format ADW IDs.
+- `adws/__tests__/triggerCommentHandling.test.ts` — Contains test data with old-format ADW IDs.
+- `adws/__tests__/adwPrReview.test.ts` — Contains test data with old-format ADW IDs.
+- `adws/__tests__/gitAgent.test.ts` — Tests for branch name agent that reference ADW IDs.
+- `adws/__tests__/workflowPhases.test.ts` — Tests for workflow initialization.
+- `adws/__tests__/branchNameGeneration.test.ts` — Tests for branch name generation.
+
+### New Files
+- `adws/__tests__/generateAdwId.test.ts` — New unit tests for the updated `generateAdwId()` function.
+
+## Implementation Plan
+
+### Phase 1: Foundation
+Modify the core `generateAdwId()` function in `adws/core/utils.ts` to accept an optional `summary` parameter. When provided, generate a human-readable ID using the slugified summary (max 20 chars) instead of a timestamp. When not provided, fall back to the existing timestamp-based format. Also update the `extractAdwIdFromComment()` regex in `adws/github/workflowCommentsBase.ts` to match both old and new ADW ID formats.
+
+### Phase 2: Core Implementation
+Update `initializeWorkflow()` and `initializePRReviewWorkflow()` in `adws/workflowPhases.ts` to accept a nullable `adwId` parameter. When `null`, generate the ADW ID after fetching the issue/PR, using the title as the summary. Then update all orchestrator callers (`adwPlan.tsx`, `adwBuild.tsx`, `adwPlanBuild.tsx`, `adwPlanBuildTest.tsx`, `adwPrReview.tsx`) to pass `null` instead of calling `generateAdwId()` directly (except `adwTest.tsx` which has no issue context).
+
+### Phase 3: Integration
+Update all existing tests to work with both old and new ADW ID formats. Add new unit tests for `generateAdwId()` with various summary inputs. Verify that recovery from old-format ADW IDs in GitHub comments still works correctly.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### Step 1: Update `generateAdwId()` in `adws/core/utils.ts`
+- Modify the function signature to accept an optional `summary` parameter: `generateAdwId(summary?: string): string`
+- When `summary` is provided and non-empty after slugification:
+  - Slugify the summary using the existing `slugify()` function
+  - Truncate to 20 characters maximum
+  - Remove any trailing hyphen caused by truncation
+  - Generate format: `adw-{slugified-summary}-{random}`
+- When `summary` is not provided or produces an empty slug:
+  - Fall back to existing format: `adw-{timestamp}-{random}`
+- The random suffix remains 6 characters of base-36 alphanumeric
+
+### Step 2: Create unit tests for `generateAdwId()` in `adws/__tests__/generateAdwId.test.ts`
+- Test that providing a summary produces `adw-{slug}-{random}` format
+- Test that the summary portion is max 20 characters
+- Test that trailing hyphens from truncation are removed
+- Test that special characters are properly slugified
+- Test that an empty summary falls back to timestamp format
+- Test that no summary parameter falls back to timestamp format
+- Test that the random suffix is always 6 alphanumeric characters
+- Test uniqueness (two calls with same summary produce different IDs)
+
+### Step 3: Update `extractAdwIdFromComment()` regex in `adws/github/workflowCommentsBase.ts`
+- Change the regex from `` /`(adw-\d+-[a-z0-9]+)`/ `` to `` /`(adw-[a-z0-9][a-z0-9-]*[a-z0-9])`/ ``
+- This new pattern matches both old format (`adw-1770819277126-v2n6pm`) and new format (`adw-replace-timestamp-v2n6pm`)
+- Verify the regex still correctly extracts ADW IDs enclosed in backticks
+
+### Step 4: Update `initializeWorkflow()` in `adws/workflowPhases.ts`
+- Change the `adwId` parameter type from `string` to `string | null`
+- After fetching the issue (line ~102), resolve the ADW ID: `const resolvedAdwId = adwId ?? generateAdwId(issue.title);`
+- Use `resolvedAdwId` throughout the rest of the function instead of `adwId`
+- Update the `WorkflowConfig` interface — the `adwId` field remains `string` (it's always resolved by this point)
+
+### Step 5: Update `initializePRReviewWorkflow()` in `adws/workflowPhases.ts`
+- Change the `adwId` parameter type from `string` to `string | null`
+- After fetching PR details (line ~586), resolve the ADW ID: `const resolvedAdwId = adwId ?? generateAdwId(prDetails.title);`
+- Use `resolvedAdwId` throughout the rest of the function
+
+### Step 6: Update orchestrator callers to pass `null` instead of generating ADW IDs directly
+- **`adws/adwPlan.tsx`** (line 97): Change `const adwId = providedAdwId || generateAdwId();` to `const adwId = providedAdwId || null;`
+- **`adws/adwPlanBuild.tsx`** (line 59): Change `const adwId = args[1] || generateAdwId();` to `const adwId = args[1] || null;`
+- **`adws/adwPlanBuildTest.tsx`** (line 63): Change `const adwId = args[1] || generateAdwId();` to `const adwId = args[1] || null;`
+- **`adws/adwPrReview.tsx`** (line 43): Change `const adwId = generateAdwId();` to `const adwId = null;` and pass to `initializePRReviewWorkflow(prNumber, adwId);`
+
+### Step 7: Update `adwBuild.tsx` to pass issue title to `generateAdwId()`
+- `adwBuild.tsx` does NOT use `initializeWorkflow()` — it has its own initialization
+- It already fetches the issue at line 145
+- Change line 149 from `const adwId = providedAdwId || generateAdwId();` to `const adwId = providedAdwId || generateAdwId(issue.title);`
+
+### Step 8: Leave `adwTest.tsx` unchanged
+- `adwTest.tsx` has no issue context available
+- The fallback to timestamp-based ID is appropriate here
+- No changes needed
+
+### Step 9: Update existing tests for regex compatibility
+- **`adws/__tests__/commentFiltering.test.ts`**: Verify test data with old-format ADW IDs still passes (backwards compatibility)
+- **`adws/__tests__/triggerCommentHandling.test.ts`**: Same verification
+- **`adws/__tests__/adwPrReview.test.ts`**: Same verification
+- Add test cases in relevant test files that use new-format ADW IDs to verify extraction works
+
+### Step 10: Update `adws/__tests__/workflowPhases.test.ts`
+- Update mock calls to `initializeWorkflow` and `initializePRReviewWorkflow` to pass `null` as the `adwId` parameter where applicable
+- Verify that the functions correctly generate ADW IDs from issue/PR titles
+
+### Step 11: Run Validation Commands
+- Run all validation commands below to ensure zero regressions
+
+## Testing Strategy
+
+### Unit Tests
+- **`generateAdwId()` tests**: Cover summary-based generation, timestamp fallback, max length enforcement, special character handling, empty/null summary, uniqueness
+- **`extractAdwIdFromComment()` tests**: Verify regex matches both old format (`adw-\d+-[a-z0-9]+`) and new format (`adw-{slug}-{random}`)
+- **Existing test suites**: Verify all pass without modification (backwards compatibility of regex)
+
+### Integration Tests
+- **Workflow initialization tests**: Verify `initializeWorkflow()` correctly generates summary-based ADW IDs when no ID is provided
+- **Comment parsing tests**: Verify that recovery from GitHub comments works with both old and new ADW ID formats
+- **Branch name generation tests**: Verify the new ADW IDs work correctly in branch name generation flow
+
+### Edge Cases
+- Empty issue title → falls back to timestamp-based ID
+- Very long issue title (>20 chars) → truncated to 20 chars with clean hyphen handling
+- Title with only special characters → produces empty slug → falls back to timestamp
+- Title with Unicode characters → slugified to ASCII → truncated
+- Recovery from old-format ADW ID in existing GitHub comments → regex still matches
+- Two simultaneous workflows on same issue → different random suffixes ensure uniqueness
+- Provided ADW ID via CLI (recovery mode) → used as-is, no regeneration
+
+## Acceptance Criteria
+- ADW IDs generated from issue titles follow the format `adw-{summary}-{random}` where summary is a max-20-char slugified version of the issue title
+- ADW IDs without issue context (e.g., `adwTest.tsx`) fall back to the existing `adw-{timestamp}-{random}` format
+- The `extractAdwIdFromComment()` regex matches both old and new ADW ID formats
+- All existing tests pass without regressions
+- New unit tests cover the `generateAdwId()` function with various inputs
+- Recovery from old-format ADW IDs in GitHub comments works correctly
+- All orchestrators (`adwPlan`, `adwBuild`, `adwPlanBuild`, `adwPlanBuildTest`, `adwPrReview`) generate summary-based ADW IDs
+
+## Validation Commands
+Execute every command to validate the feature works correctly with zero regressions.
+
+- `npm run lint` - Run linter to check for code quality issues
+- `npm run build` - Build the application to verify no build errors
+- `npm test` - Run tests to validate the feature works with zero regressions
+
+## Notes
+- IMPORTANT: strictly adhere to the coding guidelines in `/guidelines`. If necessary, refactor existing code to meet the coding guidelines as part of implementing the feature.
+- The `slugify()` function in `adws/core/utils.ts` already handles lowercasing, special character replacement, and leading/trailing hyphen removal. Reuse it for the ADW ID summary and simply truncate to 20 chars.
+- Backwards compatibility is critical: old-format ADW IDs (`adw-{timestamp}-{random}`) must still be recognized by `extractAdwIdFromComment()` for workflow recovery from previous runs.
+- The `generate_branch_name.md` Claude command does not need changes since it receives the `adw_id` variable and the Claude agent handles formatting.
+- No new libraries are required for this feature.


### PR DESCRIPTION
## Summary
Implements #121 - replace timestamp from adw id

## Implementation Plan


## Changes Made


## Testing
- [ ] All validation commands from the plan pass
- [ ] No regressions introduced
- [ ] Code follows project conventions

---
Generated by ADW Plan & Build workflow
