### PR TITLE
feat: Update the trigger to use the given adw orchestrator (#138)

### DIFF
--- a/adws/__tests__/issueClassifier.test.ts
+++ b/adws/__tests__/issueClassifier.test.ts
@@ -6,7 +6,7 @@ import {
   classifyGitHubIssue,
   getWorkflowScript,
 } from '../triggers/issueClassifier';
-import { adwCommandToIssueTypeMap, AdwSlashCommand, GitHubIssue } from '../core/dataTypes';
+import { adwCommandToIssueTypeMap, adwCommandToOrchestratorMap, AdwSlashCommand, GitHubIssue } from '../core/dataTypes';
 
 vi.mock('../core', () => ({
   log: vi.fn(),
@@ -23,6 +23,15 @@ vi.mock('../core', () => ({
     '/adw_plan_build_document': '/chore',
     '/adw_plan_build_test_review': '/feature',
     '/adw_sdlc': '/feature',
+  },
+  adwCommandToOrchestratorMap: {
+    '/adw_plan': 'adws/adwPlan.tsx',
+    '/adw_build': 'adws/adwBuild.tsx',
+    '/adw_test': 'adws/adwTest.tsx',
+    '/adw_plan_build': 'adws/adwPlanBuild.tsx',
+    '/adw_plan_build_test': 'adws/adwPlanBuildTest.tsx',
+    '/adw_plan_build_test_review': 'adws/adwPlanBuildTestReview.tsx',
+    '/adw_sdlc': 'adws/adwPlanBuildTestReview.tsx',
   },
 }));
 
@@ -368,6 +377,7 @@ describe('classifyGitHubIssue', () => {
 // ============================================================================
 
 describe('getWorkflowScript', () => {
+  // Issue-type-based routing (no ADW command)
   it('returns adwPlanBuildTest for /feature', () => {
     expect(getWorkflowScript('/feature')).toBe('adws/adwPlanBuildTest.tsx');
   });
@@ -384,17 +394,61 @@ describe('getWorkflowScript', () => {
     expect(getWorkflowScript('/pr_review')).toBe('adws/adwPlanBuild.tsx');
   });
 
+  // Mapped ADW commands route to their dedicated orchestrators
   it('returns adwPlanBuildTestReview when adwCommand is /adw_plan_build_test_review', () => {
     expect(getWorkflowScript('/feature', '/adw_plan_build_test_review')).toBe('adws/adwPlanBuildTestReview.tsx');
   });
 
-  it('ignores adwCommand when not /adw_plan_build_test_review', () => {
+  it('returns adwPlan when adwCommand is /adw_plan', () => {
+    expect(getWorkflowScript('/chore', '/adw_plan')).toBe('adws/adwPlan.tsx');
+  });
+
+  it('returns adwBuild when adwCommand is /adw_build', () => {
+    expect(getWorkflowScript('/feature', '/adw_build')).toBe('adws/adwBuild.tsx');
+  });
+
+  it('returns adwTest when adwCommand is /adw_test', () => {
+    expect(getWorkflowScript('/feature', '/adw_test')).toBe('adws/adwTest.tsx');
+  });
+
+  it('returns adwPlanBuild when adwCommand is /adw_plan_build', () => {
+    expect(getWorkflowScript('/bug', '/adw_plan_build')).toBe('adws/adwPlanBuild.tsx');
+  });
+
+  it('returns adwPlanBuildTest when adwCommand is /adw_plan_build_test', () => {
     expect(getWorkflowScript('/feature', '/adw_plan_build_test')).toBe('adws/adwPlanBuildTest.tsx');
+  });
+
+  it('returns adwPlanBuildTestReview when adwCommand is /adw_sdlc', () => {
+    expect(getWorkflowScript('/feature', '/adw_sdlc')).toBe('adws/adwPlanBuildTestReview.tsx');
+  });
+
+  // Unmapped ADW commands fall back to issue-type routing
+  it('falls back to issue-type routing when adwCommand is /adw_patch', () => {
     expect(getWorkflowScript('/bug', '/adw_patch')).toBe('adws/adwPlanBuild.tsx');
   });
 
+  it('falls back to issue-type routing when adwCommand is /adw_document', () => {
+    expect(getWorkflowScript('/chore', '/adw_document')).toBe('adws/adwPlanBuildTest.tsx');
+  });
+
+  it('falls back to issue-type routing when adwCommand is /adw_review', () => {
+    expect(getWorkflowScript('/pr_review', '/adw_review')).toBe('adws/adwPlanBuild.tsx');
+  });
+
+  // ADW command takes priority over issueType
   it('uses adwCommand override regardless of issueType', () => {
     expect(getWorkflowScript('/bug', '/adw_plan_build_test_review')).toBe('adws/adwPlanBuildTestReview.tsx');
     expect(getWorkflowScript('/chore', '/adw_plan_build_test_review')).toBe('adws/adwPlanBuildTestReview.tsx');
+    expect(getWorkflowScript('/feature', '/adw_plan')).toBe('adws/adwPlan.tsx');
+    expect(getWorkflowScript('/pr_review', '/adw_plan_build_test')).toBe('adws/adwPlanBuildTest.tsx');
   });
+
+  // Parametric test over all mapped entries
+  it.each(Object.entries(adwCommandToOrchestratorMap))(
+    'routes %s to %s via adwCommandToOrchestratorMap',
+    (command, expectedScript) => {
+      expect(getWorkflowScript('/feature', command as AdwSlashCommand)).toBe(expectedScript);
+    }
+  );
 });

--- a/adws/core/dataTypes.ts
+++ b/adws/core/dataTypes.ts
@@ -47,6 +47,23 @@ export const adwCommandToIssueTypeMap: Record<AdwSlashCommand, IssueClassSlashCo
 };
 
 /**
+ * Maps ADW workflow commands to their dedicated orchestrator scripts.
+ * Commands present in this map bypass issue-type-based routing and route
+ * directly to the specified orchestrator. Commands omitted from this map
+ * (e.g., `/adw_review`, `/adw_document`, `/adw_patch`) fall back to
+ * issue-type-based routing in `getWorkflowScript()`.
+ */
+export const adwCommandToOrchestratorMap: Partial<Record<AdwSlashCommand, string>> = {
+  '/adw_plan': 'adws/adwPlan.tsx',
+  '/adw_build': 'adws/adwBuild.tsx',
+  '/adw_test': 'adws/adwTest.tsx',
+  '/adw_plan_build': 'adws/adwPlanBuild.tsx',
+  '/adw_plan_build_test': 'adws/adwPlanBuildTest.tsx',
+  '/adw_plan_build_test_review': 'adws/adwPlanBuildTestReview.tsx',
+  '/adw_sdlc': 'adws/adwPlanBuildTestReview.tsx',
+} as const;
+
+/**
  * Result from the /classify_adw command extraction.
  */
 export interface AdwClassificationResult {

--- a/adws/core/index.ts
+++ b/adws/core/index.ts
@@ -36,7 +36,7 @@ export type {
 } from './dataTypes';
 
 // Prefix maps for consistent branch naming and commit messages
-export { commitPrefixMap, branchPrefixMap, adwCommandToIssueTypeMap } from './dataTypes';
+export { commitPrefixMap, branchPrefixMap, adwCommandToIssueTypeMap, adwCommandToOrchestratorMap } from './dataTypes';
 
 // Utilities
 export {

--- a/adws/triggers/issueClassifier.ts
+++ b/adws/triggers/issueClassifier.ts
@@ -13,6 +13,7 @@ import {
   AdwSlashCommand,
   AdwClassificationResult,
   adwCommandToIssueTypeMap,
+  adwCommandToOrchestratorMap,
   log,
   GitHubIssue,
 } from '../core';
@@ -253,18 +254,21 @@ ${issue.body || 'No description provided.'}`;
 /**
  * Determines which workflow script to use based on issue type and optional ADW command.
  *
- * - /adw_plan_build_test_review routes to adwPlanBuildTestReview.tsx
- * - /feature and /chore use adwPlanBuildTest.tsx (includes Test phase)
- * - /bug and /pr_review use adwPlanBuild.tsx (no Test phase)
+ * Routing priority:
+ * 1. If `adwCommand` is provided and exists in `adwCommandToOrchestratorMap`, use the mapped orchestrator.
+ * 2. Otherwise, fall back to issue-type-based routing:
+ *    - /feature and /chore use adwPlanBuildTest.tsx (includes Test phase)
+ *    - /bug and /pr_review use adwPlanBuild.tsx (no Test phase)
  *
  * @param issueType - The classified issue type
  * @param adwCommand - Optional ADW command for precise orchestrator routing
  * @returns The workflow script path to spawn
  */
 export function getWorkflowScript(issueType: IssueClassSlashCommand, adwCommand?: AdwSlashCommand): string {
-  // Route specific ADW commands to their dedicated orchestrators
-  if (adwCommand === '/adw_plan_build_test_review') {
-    return 'adws/adwPlanBuildTestReview.tsx';
+  // Route ADW commands to their dedicated orchestrators when mapped
+  if (adwCommand) {
+    const orchestrator = adwCommandToOrchestratorMap[adwCommand];
+    if (orchestrator) return orchestrator;
   }
 
   switch (issueType) {

--- a/specs/issue-138-plan.md
+++ b/specs/issue-138-plan.md
@@ -1,0 +1,117 @@
+# Feature: Use Given ADW Orchestrator from Issue
+
+## Feature Description
+Update the ADW trigger system to route issues to the orchestrator specified by the ADW command in the issue body, rather than only using the issue-type-based defaults. Currently, `getWorkflowScript()` only handles `/adw_plan_build_test_review` as a direct orchestrator override. All other ADW commands are mapped to issue types first, and then the issue type determines which orchestrator to use via a fixed switch statement. This feature adds a comprehensive mapping from ADW commands to their corresponding orchestrator scripts, so that when a user specifies an ADW command like `/adw_plan_build` in an issue, the trigger spawns the matching `adwPlanBuild.tsx` orchestrator directly. The default issue-type-based routing remains as the fallback for commands without a dedicated orchestrator or when no ADW command is specified.
+
+## User Story
+As a developer using the ADW system
+I want to specify which orchestrator to use via an ADW command in my issue
+So that I can control the exact workflow stages executed for my issue
+
+## Problem Statement
+The `getWorkflowScript()` function only has a special case for `/adw_plan_build_test_review`. All other ADW commands (e.g., `/adw_plan`, `/adw_build`, `/adw_plan_build`, `/adw_plan_build_test`) are ignored when determining the orchestrator, and routing falls back to the issue type. This means specifying `/adw_plan_build` in an issue classified as `/feature` still routes to `adwPlanBuildTest.tsx` instead of the intended `adwPlanBuild.tsx`. Users cannot control which orchestrator runs unless they happen to use the one hard-coded special case.
+
+## Solution Statement
+Add a `adwCommandToOrchestratorMap` constant in `dataTypes.ts` that maps each ADW command to its corresponding orchestrator script path (where one exists). Update `getWorkflowScript()` in `issueClassifier.ts` to consult this map first: if the ADW command has a mapped orchestrator, return it directly; otherwise fall back to the existing issue-type-based switch. This approach is data-driven, extensible, and preserves backward compatibility.
+
+## Relevant Files
+Use these files to implement the feature:
+
+- `adws/core/dataTypes.ts` - Contains `AdwSlashCommand` type and `adwCommandToIssueTypeMap`. Add the new `adwCommandToOrchestratorMap` here alongside the existing mapping constants.
+- `adws/triggers/issueClassifier.ts` - Contains `getWorkflowScript()` which needs to be updated to use the new orchestrator map instead of only handling a single ADW command.
+- `adws/__tests__/issueClassifier.test.ts` - Contains tests for `getWorkflowScript()`. Needs updated and new tests covering orchestrator routing for all ADW commands.
+
+## Implementation Plan
+### Phase 1: Foundation
+Add the `adwCommandToOrchestratorMap` constant to `adws/core/dataTypes.ts`. This map provides the single source of truth for which ADW commands have dedicated orchestrator scripts. Commands without a dedicated orchestrator (e.g., `/adw_review`, `/adw_document`, `/adw_patch`) are omitted from the map, causing the system to fall back to issue-type-based routing.
+
+### Phase 2: Core Implementation
+Update `getWorkflowScript()` in `adws/triggers/issueClassifier.ts` to look up the ADW command in `adwCommandToOrchestratorMap` before falling back to the issue-type switch. Remove the hard-coded `/adw_plan_build_test_review` check since it will be covered by the map.
+
+### Phase 3: Integration
+Update existing tests and add comprehensive new tests in `adws/__tests__/issueClassifier.test.ts` to verify that every ADW command with a mapped orchestrator routes correctly, and that commands without a mapped orchestrator fall back to issue-type-based routing.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### Step 1: Add `adwCommandToOrchestratorMap` to `adws/core/dataTypes.ts`
+- Add a new exported constant `adwCommandToOrchestratorMap` of type `Partial<Record<AdwSlashCommand, string>>` after the existing `adwCommandToIssueTypeMap`.
+- Map each ADW command that has a dedicated orchestrator script:
+  - `/adw_plan` → `'adws/adwPlan.tsx'`
+  - `/adw_build` → `'adws/adwBuild.tsx'`
+  - `/adw_test` → `'adws/adwTest.tsx'`
+  - `/adw_plan_build` → `'adws/adwPlanBuild.tsx'`
+  - `/adw_plan_build_test` → `'adws/adwPlanBuildTest.tsx'`
+  - `/adw_plan_build_test_review` → `'adws/adwPlanBuildTestReview.tsx'`
+  - `/adw_sdlc` → `'adws/adwPlanBuildTestReview.tsx'` (most complete orchestrator)
+- Omit ADW commands without dedicated orchestrators: `/adw_review`, `/adw_document`, `/adw_patch`, `/adw_plan_build_review`, `/adw_plan_build_document`. These will fall back to issue-type-based routing.
+- Add a JSDoc comment explaining the purpose and fallback behavior.
+- Export the new constant from `adws/core/index.ts` if not already re-exported via barrel.
+
+### Step 2: Update `getWorkflowScript()` in `adws/triggers/issueClassifier.ts`
+- Import `adwCommandToOrchestratorMap` from `'../core'`.
+- Replace the hard-coded `/adw_plan_build_test_review` check with a lookup in `adwCommandToOrchestratorMap`.
+- When `adwCommand` is provided and exists in the map, return the mapped orchestrator script path.
+- When `adwCommand` is not in the map (or is undefined), fall through to the existing issue-type switch.
+- Update the JSDoc comment for `getWorkflowScript()` to document the new behavior.
+
+### Step 3: Update tests in `adws/__tests__/issueClassifier.test.ts`
+- Add `adwCommandToOrchestratorMap` to the mock for `'../core'`.
+- Update the existing `getWorkflowScript` test: `'returns adwPlanBuildTestReview when adwCommand is /adw_plan_build_test_review'` — this test should still pass since the behavior is unchanged (now driven by the map instead of a hard-coded check).
+- Update the test `'ignores adwCommand when not /adw_plan_build_test_review'` — this test needs to change since `/adw_plan_build_test` now routes to `adwPlanBuildTest.tsx` via the map. Update it to test only commands that are NOT in the map (e.g., `/adw_patch`, `/adw_document`).
+- Add new tests for each mapped ADW command to verify correct orchestrator routing:
+  - `/adw_plan` → `adwPlan.tsx`
+  - `/adw_build` → `adwBuild.tsx`
+  - `/adw_test` → `adwTest.tsx`
+  - `/adw_plan_build` → `adwPlanBuild.tsx`
+  - `/adw_plan_build_test` → `adwPlanBuildTest.tsx`
+  - `/adw_sdlc` → `adwPlanBuildTestReview.tsx`
+- Add tests for unmapped commands falling back to issue-type routing:
+  - `/adw_patch` with issueType `/bug` → `adwPlanBuild.tsx`
+  - `/adw_document` with issueType `/chore` → `adwPlanBuildTest.tsx`
+  - `/adw_review` with issueType `/pr_review` → `adwPlanBuild.tsx`
+- Add a parametric test that iterates over all entries in `adwCommandToOrchestratorMap` to verify each routes to the correct orchestrator.
+
+### Step 4: Run validation commands
+- Run `npm run lint` to ensure code quality.
+- Run `npm run build` to verify no build errors.
+- Run `npm test` to validate all tests pass with zero regressions.
+
+## Testing Strategy
+### Unit Tests
+- Test `getWorkflowScript()` with every ADW command that has a mapped orchestrator to verify direct routing.
+- Test `getWorkflowScript()` with ADW commands that lack a mapped orchestrator to verify fallback to issue-type routing.
+- Test `getWorkflowScript()` with no ADW command to verify default issue-type routing.
+- Parametric test iterating over `adwCommandToOrchestratorMap` entries to ensure comprehensive coverage.
+
+### Integration Tests
+- The existing `classifyIssueForTrigger` and `classifyGitHubIssue` tests indirectly validate the end-to-end flow. No additional integration tests are needed since the change is isolated to `getWorkflowScript()`.
+
+### Edge Cases
+- `adwCommand` is `undefined` — should fall back to issue-type routing.
+- `adwCommand` is a valid `AdwSlashCommand` but not in the orchestrator map (e.g., `/adw_patch`) — should fall back to issue-type routing.
+- `adwCommand` is mapped but `issueType` would route differently — the map should take priority.
+- `issueType` is an unexpected value with no ADW command — should use the default fallback (`adwPlanBuildTest.tsx`).
+
+## Acceptance Criteria
+- All ADW commands with dedicated orchestrators (`/adw_plan`, `/adw_build`, `/adw_test`, `/adw_plan_build`, `/adw_plan_build_test`, `/adw_plan_build_test_review`, `/adw_sdlc`) route to their corresponding orchestrator script when specified in an issue.
+- ADW commands without dedicated orchestrators (`/adw_review`, `/adw_document`, `/adw_patch`, `/adw_plan_build_review`, `/adw_plan_build_document`) fall back to issue-type-based routing.
+- When no ADW command is specified, the default issue-type-based routing is unchanged.
+- The `adwCommandToOrchestratorMap` is the single source of truth for ADW-to-orchestrator mapping, making it easy to add new orchestrators in the future.
+- All existing tests continue to pass.
+- New tests cover all mapped and unmapped ADW commands.
+- `npm run lint`, `npm run build`, and `npm test` all pass with zero errors.
+
+## Validation Commands
+Execute every command to validate the feature works correctly with zero regressions.
+
+- `npm run lint` - Run linter to check for code quality issues
+- `npm run build` - Build the application to verify no build errors
+- `npm test` - Run tests to validate the feature works with zero regressions
+
+## Notes
+- IMPORTANT: strictly adhere to the coding guidelines in `/guidelines`. If necessary, refactor existing code to meet the coding guidelines as part of implementing the feature.
+- This feature does not affect the UI, so no E2E test is needed.
+- The `adwClearComments.tsx` script is a utility, not a workflow orchestrator, and is intentionally excluded from the map.
+- The `adwPrReview.tsx` script is triggered separately by PR review events and is not part of the ADW command routing, so it is also excluded from the map.
+- Future orchestrators can be added by simply extending `adwCommandToOrchestratorMap` with new entries — no changes to `getWorkflowScript()` logic will be needed.


### PR DESCRIPTION
## Summary
Implements #138 - Update the trigger to use the given adw orchestrator

## Implementation Plan


## Changes Made


## Testing
- [ ] All validation commands from the plan pass
- [ ] No regressions introduced
- [ ] Code follows project conventions

---
Generated by ADW Plan & Build workflow
