### PR TITLE
feat: ADW flow ends when plan file cannot be found (#156)

### DIFF
--- a/adws/__tests__/planAgent.test.ts
+++ b/adws/__tests__/planAgent.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'fs';
+import { getPlanFilePath, planFileExists } from '../agents/planAgent';
+
+vi.mock('fs');
+
+describe('getPlanFilePath', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns new-convention file when it exists in specs directory', () => {
+    vi.mocked(fs.readdirSync).mockReturnValue([
+      'issue-42-adw-abc123-sdlc_planner-fix-login.md',
+      'other-file.md',
+    ] as unknown as fs.Dirent[]);
+
+    const result = getPlanFilePath(42);
+
+    expect(result).toBe('specs/issue-42-adw-abc123-sdlc_planner-fix-login.md');
+  });
+
+  it('returns legacy file when only legacy exists', () => {
+    vi.mocked(fs.readdirSync).mockReturnValue([
+      'issue-42-plan.md',
+      'other-file.md',
+    ] as unknown as fs.Dirent[]);
+    vi.mocked(fs.statSync).mockReturnValue({ isFile: () => true, size: 100 } as fs.Stats);
+
+    const result = getPlanFilePath(42);
+
+    expect(result).toBe('specs/issue-42-plan.md');
+  });
+
+  it('returns legacy fallback path when no matching file exists', () => {
+    vi.mocked(fs.readdirSync).mockReturnValue([
+      'issue-99-adw-xyz-sdlc_planner-other.md',
+    ] as unknown as fs.Dirent[]);
+    vi.mocked(fs.statSync).mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    const result = getPlanFilePath(42);
+
+    expect(result).toBe('specs/issue-42-plan.md');
+  });
+
+  it('returns legacy fallback when specs directory does not exist', () => {
+    vi.mocked(fs.readdirSync).mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    const result = getPlanFilePath(42);
+
+    expect(result).toBe('specs/issue-42-plan.md');
+  });
+
+  it('searches within worktreePath when provided', () => {
+    vi.mocked(fs.readdirSync).mockReturnValue([
+      'issue-10-adw-def456-sdlc_planner-add-feature.md',
+    ] as unknown as fs.Dirent[]);
+
+    const result = getPlanFilePath(10, '/my/worktree');
+
+    expect(fs.readdirSync).toHaveBeenCalledWith('/my/worktree/specs');
+    expect(result).toBe('specs/issue-10-adw-def456-sdlc_planner-add-feature.md');
+  });
+
+  it('checks legacy file with worktreePath prefix', () => {
+    vi.mocked(fs.readdirSync).mockReturnValue([
+      'unrelated-file.md',
+    ] as unknown as fs.Dirent[]);
+    vi.mocked(fs.statSync).mockReturnValue({ isFile: () => true, size: 50 } as fs.Stats);
+
+    const result = getPlanFilePath(10, '/my/worktree');
+
+    expect(fs.statSync).toHaveBeenCalledWith('/my/worktree/specs/issue-10-plan.md');
+    expect(result).toBe('specs/issue-10-plan.md');
+  });
+});
+
+describe('planFileExists', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns true when new-convention file exists and has content', () => {
+    vi.mocked(fs.readdirSync).mockReturnValue([
+      'issue-5-adw-abc-sdlc_planner-my-plan.md',
+    ] as unknown as fs.Dirent[]);
+    vi.mocked(fs.statSync).mockReturnValue({ isFile: () => true, size: 200 } as fs.Stats);
+
+    expect(planFileExists(5)).toBe(true);
+  });
+
+  it('returns true when legacy file exists and has content', () => {
+    vi.mocked(fs.readdirSync).mockReturnValue([] as unknown as fs.Dirent[]);
+    vi.mocked(fs.statSync).mockImplementation((filePath) => {
+      if (String(filePath) === 'specs/issue-5-plan.md') {
+        return { isFile: () => true, size: 100 } as fs.Stats;
+      }
+      throw new Error('ENOENT');
+    });
+
+    // readdirSync returns empty, so findPlanFile's legacy check via statSync is called
+    // But the first statSync call in findPlanFile for the legacy path also returns stats
+    expect(planFileExists(5)).toBe(true);
+  });
+
+  it('returns false when no file exists', () => {
+    vi.mocked(fs.readdirSync).mockReturnValue([] as unknown as fs.Dirent[]);
+    vi.mocked(fs.statSync).mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    expect(planFileExists(5)).toBe(false);
+  });
+
+  it('returns false when file exists but is empty', () => {
+    vi.mocked(fs.readdirSync).mockReturnValue([
+      'issue-5-adw-abc-sdlc_planner-my-plan.md',
+    ] as unknown as fs.Dirent[]);
+    vi.mocked(fs.statSync).mockReturnValue({ isFile: () => true, size: 0 } as fs.Stats);
+
+    expect(planFileExists(5)).toBe(false);
+  });
+
+  it('uses worktreePath for full path resolution', () => {
+    vi.mocked(fs.readdirSync).mockReturnValue([
+      'issue-7-adw-xyz-sdlc_planner-task.md',
+    ] as unknown as fs.Dirent[]);
+    vi.mocked(fs.statSync).mockReturnValue({ isFile: () => true, size: 300 } as fs.Stats);
+
+    expect(planFileExists(7, '/worktree/path')).toBe(true);
+    expect(fs.statSync).toHaveBeenCalledWith(
+      '/worktree/path/specs/issue-7-adw-xyz-sdlc_planner-task.md'
+    );
+  });
+});

--- a/adws/__tests__/tokenLimitRecovery.test.ts
+++ b/adws/__tests__/tokenLimitRecovery.test.ts
@@ -53,7 +53,7 @@ vi.mock('../github', () => ({
 
 vi.mock('../agents', () => ({
   runPlanAgent: vi.fn(),
-  getPlanFilePath: vi.fn().mockReturnValue('specs/issue-1-plan.md'),
+  getPlanFilePath: vi.fn().mockReturnValue('specs/issue-1-adw-test123-sdlc_planner-test.md'),
   planFileExists: vi.fn().mockReturnValue(false),
   runBuildAgent: vi.fn(),
   runPrReviewPlanAgent: vi.fn(),

--- a/adws/__tests__/workflowPhases.test.ts
+++ b/adws/__tests__/workflowPhases.test.ts
@@ -109,7 +109,7 @@ vi.mock('../agents', () => ({
     output: 'Plan created',
     totalCostUsd: 0.5,
   }),
-  getPlanFilePath: vi.fn().mockReturnValue('specs/issue-1-plan.md'),
+  getPlanFilePath: vi.fn().mockReturnValue('specs/issue-1-adw-test123-sdlc_planner-test.md'),
   planFileExists: vi.fn().mockReturnValue(false),
   runBuildAgent: vi.fn().mockResolvedValue({
     success: true,
@@ -429,7 +429,7 @@ describe('executeBuildPhase', () => {
     const result = await executeBuildPhase(config);
 
     expect(fs.readFileSync).toHaveBeenCalledWith(
-      path.join('/mock/worktree', 'specs/issue-1-plan.md'),
+      path.join('/mock/worktree', 'specs/issue-1-adw-test123-sdlc_planner-test.md'),
       'utf-8'
     );
     expect(runBuildAgent).toHaveBeenCalled();
@@ -786,7 +786,7 @@ describe('executePRReviewPlanPhase', () => {
     const result = await executePRReviewPlanPhase(config);
 
     expect(fs.readFileSync).toHaveBeenCalledWith(
-      path.join('/mock/worktree', 'specs/issue-1-plan.md'),
+      path.join('/mock/worktree', 'specs/issue-1-adw-test123-sdlc_planner-test.md'),
       'utf-8'
     );
     expect(runPrReviewPlanAgent).toHaveBeenCalledWith(
@@ -1113,7 +1113,7 @@ describe('executeReviewPhase', () => {
 
     expect(runReviewWithRetry).toHaveBeenCalledWith(expect.objectContaining({
       adwId: 'test-adw-id',
-      specFile: 'specs/issue-1-plan.md',
+      specFile: 'specs/issue-1-adw-test123-sdlc_planner-test.md',
       logsDir: '/mock/logs',
       maxRetries: expect.any(Number),
       branchName: 'feature/issue-1-test',

--- a/adws/adwBuild.tsx
+++ b/adws/adwBuild.tsx
@@ -23,6 +23,7 @@
  */
 
 import * as fs from 'fs';
+import * as path from 'path';
 import {
   log,
   generateAdwId,
@@ -92,12 +93,13 @@ async function main(): Promise<void> {
   }
 
   // Read plan content
+  const fullPlanPath = cwd ? path.join(cwd, planPath) : planPath;
   let planContent: string;
   try {
-    planContent = fs.readFileSync(planPath, 'utf-8');
-    log(`Plan loaded from: ${planPath}`, 'success');
+    planContent = fs.readFileSync(fullPlanPath, 'utf-8');
+    log(`Plan loaded from: ${fullPlanPath}`, 'success');
   } catch (error) {
-    log(`Cannot read plan file at ${planPath}: ${error}`, 'error');
+    log(`Cannot read plan file at ${fullPlanPath}: ${error}`, 'error');
     process.exit(1);
   }
 

--- a/adws/adwBuild.tsx
+++ b/adws/adwBuild.tsx
@@ -84,8 +84,8 @@ async function main(): Promise<void> {
   const branchName = getCurrentBranch(cwd || undefined);
   log(`Current branch: ${branchName}`, 'info');
 
-  const planPath = getPlanFilePath(issueNumber);
-  if (!planFileExists(issueNumber)) {
+  const planPath = getPlanFilePath(issueNumber, cwd || undefined);
+  if (!planFileExists(issueNumber, cwd || undefined)) {
     log(`Plan file not found: ${planPath}`, 'error');
     log('Run adwPlan.tsx first to generate the plan.', 'error');
     process.exit(1);

--- a/adws/agents/planAgent.ts
+++ b/adws/agents/planAgent.ts
@@ -34,9 +34,48 @@ ${commentsSection}`;
 }
 
 /**
- * Gets the path to the plan file for an issue.
+ * Finds the actual plan file path for an issue.
+ * Plan files follow the naming convention: issue-{number}-adw-{adwId}-sdlc_planner-{descriptiveName}.md
+ * Falls back to legacy naming: issue-{number}-plan.md
  */
-export function getPlanFilePath(issueNumber: number): string {
+function findPlanFile(issueNumber: number, worktreePath?: string): string | null {
+  const specsDir = worktreePath ? path.join(worktreePath, 'specs') : 'specs';
+
+  try {
+    const files = fs.readdirSync(specsDir);
+
+    // Look for new naming convention: issue-{number}-adw-{adwId}-sdlc_planner-*.md
+    for (const file of files) {
+      const pattern = new RegExp(`^issue-${issueNumber}-adw-.*-sdlc_planner-.*\\.md$`);
+      if (pattern.test(file)) {
+        return path.join('specs', file);
+      }
+    }
+
+    // Fall back to legacy naming: issue-{number}-plan.md
+    const legacyPath = `specs/issue-${issueNumber}-plan.md`;
+    const fullLegacyPath = worktreePath ? path.join(worktreePath, legacyPath) : legacyPath;
+    try {
+      fs.statSync(fullLegacyPath);
+      return legacyPath;
+    } catch {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Gets the path to the plan file for an issue.
+ * Returns the actual plan file path if it exists, otherwise returns the legacy path.
+ */
+export function getPlanFilePath(issueNumber: number, worktreePath?: string): string {
+  const foundPath = findPlanFile(issueNumber, worktreePath);
+  if (foundPath) {
+    return foundPath;
+  }
+  // Fall back to legacy naming if no file is found
   return `specs/issue-${issueNumber}-plan.md`;
 }
 
@@ -45,7 +84,7 @@ export function getPlanFilePath(issueNumber: number): string {
  * Returns true if the file exists and has content.
  */
 export function planFileExists(issueNumber: number, worktreePath?: string): boolean {
-  const planPath = getPlanFilePath(issueNumber);
+  const planPath = getPlanFilePath(issueNumber, worktreePath);
   const fullPath = worktreePath ? path.join(worktreePath, planPath) : planPath;
   try {
     const stats = fs.statSync(fullPath);

--- a/adws/phases/buildPhase.ts
+++ b/adws/phases/buildPhase.ts
@@ -36,7 +36,7 @@ export async function executeBuildPhase(config: WorkflowConfig): Promise<{ costU
   const { recoveryState, orchestratorStatePath, orchestratorName, adwId, issueNumber, issue, issueType, ctx, worktreePath, logsDir } = config;
 
   // Read plan content
-  const planPath = path.join(worktreePath, getPlanFilePath(issueNumber));
+  const planPath = path.join(worktreePath, getPlanFilePath(issueNumber, worktreePath));
   let planContent: string;
   try {
     planContent = fs.readFileSync(planPath, 'utf-8');

--- a/adws/phases/planPhase.ts
+++ b/adws/phases/planPhase.ts
@@ -52,7 +52,7 @@ export async function executePlanPhase(config: WorkflowConfig): Promise<{ costUs
   }
 
   // Plan agent step
-  const planPath = getPlanFilePath(issueNumber);
+  const planPath = getPlanFilePath(issueNumber, worktreePath);
   ctx.planPath = planPath;
   let costUsd = 0;
   let modelUsage = emptyModelUsageMap();

--- a/adws/phases/planPhase.ts
+++ b/adws/phases/planPhase.ts
@@ -85,8 +85,12 @@ export async function executePlanPhase(config: WorkflowConfig): Promise<{ costUs
       throw new Error(`Plan Agent failed: ${planResult.output}`);
     }
 
+    // Re-resolve the plan file path now that the plan agent has created the file
+    const resolvedPlanPath = getPlanFilePath(issueNumber, worktreePath);
+    ctx.planPath = resolvedPlanPath;
+
     AgentStateManager.writeState(planAgentStatePath, {
-      planFile: planPath,
+      planFile: resolvedPlanPath,
       output: planResult.output.substring(0, 1000),
       execution: AgentStateManager.completeExecution(
         AgentStateManager.createExecutionState('running'),
@@ -94,8 +98,8 @@ export async function executePlanPhase(config: WorkflowConfig): Promise<{ costUs
       ),
     });
 
-    AgentStateManager.writeState(orchestratorStatePath, { planFile: planPath });
-    AgentStateManager.appendLog(orchestratorStatePath, `Plan created: ${planPath}`);
+    AgentStateManager.writeState(orchestratorStatePath, { planFile: resolvedPlanPath });
+    AgentStateManager.appendLog(orchestratorStatePath, `Plan created: ${resolvedPlanPath}`);
 
     ctx.planOutput = planResult.output;
     postWorkflowComment(issueNumber, 'plan_created', ctx);

--- a/adws/phases/prReviewPhase.ts
+++ b/adws/phases/prReviewPhase.ts
@@ -97,7 +97,7 @@ export async function executePRReviewPlanPhase(config: PRReviewWorkflowConfig): 
   const { prNumber, issueNumber, adwId, prDetails, unaddressedComments, worktreePath, logsDir, orchestratorStatePath, ctx } = config;
   let existingPlanContent = '';
   if (issueNumber) {
-    const planPath = path.join(worktreePath, getPlanFilePath(issueNumber));
+    const planPath = path.join(worktreePath, getPlanFilePath(issueNumber, worktreePath));
     try {
       existingPlanContent = fs.readFileSync(planPath, 'utf-8');
       log(`Read existing plan from ${planPath}`, 'success');

--- a/adws/phases/workflowLifecycle.ts
+++ b/adws/phases/workflowLifecycle.ts
@@ -210,7 +210,7 @@ export async function executeReviewPhase(config: WorkflowConfig): Promise<{
   log('Phase: Review', 'info');
   AgentStateManager.appendLog(orchestratorStatePath, 'Starting review phase');
 
-  const specFile = getPlanFilePath(issueNumber);
+  const specFile = getPlanFilePath(issueNumber, worktreePath);
 
   postWorkflowComment(issueNumber, 'review_running', ctx);
 

--- a/specs/issue-156-adw-lguusb-sdlc_planner-fix-plan-file-lookup.md
+++ b/specs/issue-156-adw-lguusb-sdlc_planner-fix-plan-file-lookup.md
@@ -1,0 +1,124 @@
+# Bug: ADW flow ends when plan file cannot be found
+
+## Metadata
+issueNumber: `156`
+adwId: `adw-adw-flow-ends-when-p-lguusb`
+issueJson: `{"title":"ADW flow ends when plan file cannot be found","body":"Sometimes the adw fails because the plan file cannot be found. Find out why and fix the problem.\n\nUse github issue 154 and the comments to solve the bug.\n\nHint, the plan naming has changed but the implementation has not been updated accordingly. Make sure that all adws use the new naming.","number":156,"state":"OPEN","author":"paysdoc"}`
+
+## Bug Description
+ADW (AI Developer Workflow) orchestrators fail with `ENOENT: no such file or directory` errors when trying to read plan files. The plan agent creates files using the **new** naming convention (`issue-{N}-adw-{adwId}-sdlc_planner-{descriptiveName}.md`) as instructed by the slash commands (`/bug`, `/feature`, `/chore`), but the code that looks up plan files was hardcoded to expect the **legacy** naming convention (`issue-{N}-plan.md`). This mismatch causes the build phase and other downstream phases to fail.
+
+**Actual behavior:** The workflow errors out with `Cannot read plan file at .../specs/issue-{N}-plan.md: Error: ENOENT: no such file or directory`.
+
+**Expected behavior:** The workflow should find and read the plan file regardless of whether it uses the new or legacy naming convention.
+
+## Problem Statement
+The plan file naming convention changed from `issue-{N}-plan.md` to `issue-{N}-adw-{adwId}-sdlc_planner-{descriptiveName}.md` (as defined in `.claude/commands/bug.md`, `.claude/commands/feature.md`, `.claude/commands/chore.md`), but the `getPlanFilePath()` function and some call sites were not updated to search for files matching the new pattern. A partial fix was applied in commit `3023a18` that updates `getPlanFilePath()` to search `specs/` for matching files, but two remaining issues exist:
+
+1. **`planPhase.ts:55`** — calls `getPlanFilePath()` BEFORE the plan agent creates the file, resulting in the legacy fallback path being stored in state and context. After the plan agent runs, the path should be re-resolved.
+2. **`adwBuild.tsx:97`** — reads the plan file using the relative path from `getPlanFilePath()` without joining it with the `cwd` parameter, so when running from a different working directory (worktree), the read fails.
+
+## Solution Statement
+1. In `planPhase.ts`, re-resolve the plan file path AFTER the plan agent has finished creating it, so the correct (new-convention) path is stored in state and context.
+2. In `adwBuild.tsx`, join the `cwd` with the plan path when reading the file content, consistent with how `buildPhase.ts:39` does it.
+3. Add unit tests for `findPlanFile()`, `getPlanFilePath()`, and `planFileExists()` to prevent regressions.
+
+## Steps to Reproduce
+1. Create a GitHub issue (e.g., issue #154 — "Move issue classifier").
+2. Trigger an ADW workflow (e.g., `adwPlanBuildTestReview`).
+3. The plan agent runs and creates a file like `specs/issue-154-adw-dh8ryj-sdlc_planner-move-issue-classifier.md`.
+4. The build phase calls `getPlanFilePath(154)` which (before the fix) returned `specs/issue-154-plan.md`.
+5. The build phase tries to read `specs/issue-154-plan.md` — file not found, workflow crashes.
+
+Evidence from issue #154 comments:
+- Plan was created as: `specs/issue-154-adw--sdlc_planner-move-issue-classifier.md`
+- Error: `Cannot read plan file at .../specs/issue-154-plan.md: Error: ENOENT: no such file or directory`
+
+## Root Cause Analysis
+The slash commands (`.claude/commands/bug.md`, `.claude/commands/feature.md`, `.claude/commands/chore.md`) instruct the plan agent to create plan files with the naming pattern:
+```
+specs/issue-{issueNumber}-adw-{adwId}-sdlc_planner-{descriptiveName}.md
+```
+
+However, the `getPlanFilePath()` function in `adws/agents/planAgent.ts` was hardcoded to return:
+```
+specs/issue-{issueNumber}-plan.md
+```
+
+This was partially fixed in commit `3023a18` by adding a `findPlanFile()` function that searches the `specs/` directory. Two remaining issues:
+
+1. **Timing issue in `planPhase.ts`**: `getPlanFilePath()` is called on line 55 (before the plan agent runs on line 75). At that point, no file exists yet, so `findPlanFile()` returns `null` and the function falls back to the legacy name. The stale path is stored in `ctx.planPath` and state. While downstream phases re-resolve the path, the stored path is misleading and could cause issues if any code relies on it.
+
+2. **Missing path join in `adwBuild.tsx`**: On line 97, `fs.readFileSync(planPath, 'utf-8')` uses the relative path directly. When `cwd` is set (worktree scenario), the process working directory differs from the worktree directory, so the relative path won't find the file. Compare with `buildPhase.ts:39` which correctly does `path.join(worktreePath, getPlanFilePath(...))`.
+
+## Relevant Files
+Use these files to fix the bug:
+
+- `adws/agents/planAgent.ts` — Contains `findPlanFile()`, `getPlanFilePath()`, and `planFileExists()` functions. The core logic for plan file lookup. Already partially fixed in commit `3023a18`.
+- `adws/phases/planPhase.ts` — Contains `executePlanPhase()`. Calls `getPlanFilePath()` before the plan agent runs (line 55), stores the stale legacy path in context and state. Needs to re-resolve after plan creation.
+- `adws/adwBuild.tsx` — Standalone build workflow. Reads plan file on line 97 without joining `cwd` to the path. Needs path join fix.
+- `adws/phases/buildPhase.ts` — Contains `executeBuildPhase()`. Already correctly joins `worktreePath` with `getPlanFilePath()` on line 39. Reference implementation.
+- `adws/phases/prReviewPhase.ts` — Contains `executePRReviewPlanPhase()`. Already correctly joins `worktreePath` with `getPlanFilePath()` on line 100. Reference implementation.
+- `adws/phases/workflowLifecycle.ts` — Contains `executeReviewPhase()`. Uses `getPlanFilePath()` on line 213 but passes the result as `specFile` to `runReviewWithRetry()` without joining worktree path. Needs verification.
+- `adws/__tests__/workflowPhases.test.ts` — Existing tests for workflow phases. Mocks `getPlanFilePath` to return legacy name. Should be updated.
+- `guidelines/coding_guidelines.md` — Coding guidelines to follow.
+
+### New Files
+- `adws/__tests__/planAgent.test.ts` — New unit tests for `findPlanFile()`, `getPlanFilePath()`, and `planFileExists()`.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### Step 1: Read relevant files and understand current state
+- Read `adws/agents/planAgent.ts` to understand the current `findPlanFile()`, `getPlanFilePath()`, and `planFileExists()` implementations.
+- Read `adws/phases/planPhase.ts` to understand how plan path is resolved and stored.
+- Read `adws/adwBuild.tsx` to understand the standalone build workflow path handling.
+- Read `adws/phases/buildPhase.ts` as reference for correct path joining.
+- Read `adws/phases/workflowLifecycle.ts` to verify `executeReviewPhase()` path handling.
+- Read `guidelines/coding_guidelines.md` for coding standards.
+
+### Step 2: Fix plan path re-resolution in `planPhase.ts`
+- In `adws/phases/planPhase.ts`, after the plan agent completes successfully (after line 86, inside the `if` block), re-resolve the plan file path by calling `getPlanFilePath(issueNumber, worktreePath)` again.
+- Update `ctx.planPath` with the re-resolved path.
+- Update the state writes on lines 89 and 97 to use the re-resolved path instead of the stale `planPath` variable.
+- This ensures the correct (new-convention) path is stored in context and state after the plan agent creates the file.
+
+### Step 3: Fix plan file reading in `adwBuild.tsx`
+- In `adws/adwBuild.tsx`, on line 97 where `fs.readFileSync(planPath, 'utf-8')` is called, join the `cwd` with `planPath` when `cwd` is provided.
+- Use the same pattern as `buildPhase.ts:39`: `const fullPlanPath = cwd ? path.join(cwd, planPath) : planPath;`
+- Update the `readFileSync` call to use `fullPlanPath`.
+- Update the error message on line 100 to reference `fullPlanPath`.
+- Also update the log message on line 98 to reference `fullPlanPath`.
+
+### Step 4: Verify `workflowLifecycle.ts` review phase path handling
+- In `adws/phases/workflowLifecycle.ts`, line 213: `const specFile = getPlanFilePath(issueNumber, worktreePath);`
+- Verify that `runReviewWithRetry()` receives the relative spec file path and handles the worktree path correctly internally. If it needs the full path, join with `worktreePath` similarly.
+- Read `adws/agents/reviewAgent.ts` to check how `specFile` is used. If it's passed as an argument to the claude agent (which runs in `cwd: worktreePath`), then the relative path is correct. Otherwise, join with `worktreePath`.
+
+### Step 5: Create unit tests for plan file lookup functions
+- Create `adws/__tests__/planAgent.test.ts` with tests for:
+  - `getPlanFilePath()` — returns new-convention file when it exists, falls back to legacy when only legacy exists, returns legacy fallback when no file exists.
+  - `planFileExists()` — returns `true` when new-convention file exists, returns `true` when legacy file exists, returns `false` when no file exists.
+  - Test with and without `worktreePath` parameter.
+- Mock `fs.readdirSync` and `fs.statSync` to simulate different file scenarios.
+
+### Step 6: Update existing tests to use new naming convention
+- In `adws/__tests__/workflowPhases.test.ts`, update the mock return value on line 112 from `'specs/issue-1-plan.md'` to a new-convention name (e.g., `'specs/issue-1-adw-test123-sdlc_planner-test.md'`) to ensure tests reflect the actual naming.
+- In `adws/__tests__/tokenLimitRecovery.test.ts`, update the mock return value on line 56 similarly.
+- Verify all assertions that reference the old plan file name pattern are updated.
+
+### Step 7: Run validation commands
+- Run all validation commands listed below to ensure the bug is fixed with zero regressions.
+
+## Validation Commands
+Execute every command to validate the bug is fixed with zero regressions.
+
+- `npm run lint` - Run linter to check for code quality issues
+- `npm run build` - Build the application to verify no build errors
+- `npm test` - Run tests to validate the bug is fixed with zero regressions
+
+## Notes
+- IMPORTANT: strictly adhere to the coding guidelines in `/guidelines`. If necessary, refactor existing code to meet the coding guidelines as part of fixing the bug.
+- The partial fix in commit `3023a18` (adding `findPlanFile()` with directory scanning and legacy fallback) is correct and should be preserved. The remaining work is fixing the two edge cases (timing in `planPhase.ts` and path joining in `adwBuild.tsx`) and adding proper test coverage.
+- The `patch.md` command uses a different naming convention (`specs/patch/patch-adw-{adwId}-{descriptive-name}.md`) which is handled separately and is not affected by this bug.
+- No new libraries are needed.


### PR DESCRIPTION
## Summary
Implements #156 - ADW flow ends when plan file cannot be found

## Implementation Plan


## Changes Made


## Testing
- [ ] All validation commands from the plan pass
- [ ] No regressions introduced
- [ ] Code follows project conventions

---
Generated by ADW Plan & Build workflow
