### PR TITLE
chore: #168 - Copy .env.local to worktree

### DIFF
--- a/adws/__tests__/worktreeOperations.test.ts
+++ b/adws/__tests__/worktreeOperations.test.ts
@@ -1104,7 +1104,9 @@ branch refs/heads/main
 
 `;
     vi.mocked(execSync).mockReturnValue(worktreeListOutput);
-    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.existsSync).mockImplementation(
+      (p) => p === '/mock/project/.env'
+    );
     vi.mocked(fs.copyFileSync).mockReturnValue(undefined);
 
     copyEnvToWorktree('/mock/project/.worktrees/feature-branch');
@@ -1114,6 +1116,81 @@ branch refs/heads/main
       '/mock/project/.env',
       '/mock/project/.worktrees/feature-branch/.env'
     );
+  });
+
+  it('copies .env.local when it exists in main repo', () => {
+    const worktreeListOutput = `worktree /mock/project
+HEAD abc123
+branch refs/heads/main
+
+`;
+    vi.mocked(execSync).mockReturnValue(worktreeListOutput);
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.copyFileSync).mockReturnValue(undefined);
+
+    copyEnvToWorktree('/mock/project/.worktrees/feature-branch');
+
+    expect(fs.existsSync).toHaveBeenCalledWith('/mock/project/.env.local');
+    expect(fs.copyFileSync).toHaveBeenCalledWith(
+      '/mock/project/.env.local',
+      '/mock/project/.worktrees/feature-branch/.env.local'
+    );
+  });
+
+  it('copies .env but not .env.local when only .env exists', () => {
+    const worktreeListOutput = `worktree /mock/project
+HEAD abc123
+branch refs/heads/main
+
+`;
+    vi.mocked(execSync).mockReturnValue(worktreeListOutput);
+    vi.mocked(fs.existsSync).mockImplementation(
+      (p) => p === '/mock/project/.env'
+    );
+    vi.mocked(fs.copyFileSync).mockReturnValue(undefined);
+
+    copyEnvToWorktree('/mock/project/.worktrees/feature-branch');
+
+    expect(fs.copyFileSync).toHaveBeenCalledTimes(1);
+    expect(fs.copyFileSync).toHaveBeenCalledWith(
+      '/mock/project/.env',
+      '/mock/project/.worktrees/feature-branch/.env'
+    );
+  });
+
+  it('copies .env.local but not .env when only .env.local exists', () => {
+    const worktreeListOutput = `worktree /mock/project
+HEAD abc123
+branch refs/heads/main
+
+`;
+    vi.mocked(execSync).mockReturnValue(worktreeListOutput);
+    vi.mocked(fs.existsSync).mockImplementation(
+      (p) => p === '/mock/project/.env.local'
+    );
+    vi.mocked(fs.copyFileSync).mockReturnValue(undefined);
+
+    copyEnvToWorktree('/mock/project/.worktrees/feature-branch');
+
+    expect(fs.copyFileSync).toHaveBeenCalledTimes(1);
+    expect(fs.copyFileSync).toHaveBeenCalledWith(
+      '/mock/project/.env.local',
+      '/mock/project/.worktrees/feature-branch/.env.local'
+    );
+  });
+
+  it('copies neither when neither exists', () => {
+    const worktreeListOutput = `worktree /mock/project
+HEAD abc123
+branch refs/heads/main
+
+`;
+    vi.mocked(execSync).mockReturnValue(worktreeListOutput);
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+
+    copyEnvToWorktree('/mock/project/.worktrees/feature-branch');
+
+    expect(fs.copyFileSync).not.toHaveBeenCalled();
   });
 
   it('does nothing when .env does not exist (no error)', () => {

--- a/adws/github/worktreeOperations.ts
+++ b/adws/github/worktreeOperations.ts
@@ -71,8 +71,8 @@ export function getMainRepoPath(): string {
 }
 
 /**
- * Copies the .env file from the main repository to the worktree.
- * This is necessary because .env is in .gitignore and won't be included in worktrees.
+ * Copies the .env and .env.local files from the main repository to the worktree.
+ * This is necessary because these files are in .gitignore and won't be included in worktrees.
  *
  * @param worktreePath - The absolute path to the worktree
  */
@@ -87,6 +87,16 @@ export function copyEnvToWorktree(worktreePath: string): void {
       log(`Copied .env file to worktree at ${worktreePath}`, 'info');
     } else {
       log(`No .env file found in main repository at ${mainRepoPath}, skipping copy`, 'info');
+    }
+
+    const sourceEnvLocalPath = path.join(mainRepoPath, '.env.local');
+    const destEnvLocalPath = path.join(worktreePath, '.env.local');
+
+    if (fs.existsSync(sourceEnvLocalPath)) {
+      fs.copyFileSync(sourceEnvLocalPath, destEnvLocalPath);
+      log(`Copied .env.local file to worktree at ${worktreePath}`, 'info');
+    } else {
+      log(`No .env.local file found in main repository at ${mainRepoPath}, skipping copy`, 'info');
     }
   } catch (error) {
     log(`Warning: Failed to copy .env to worktree: ${error}`, 'info');

--- a/specs/issue-168-adw-e85cfm-sdlc_planner-copy-env-local-worktree.md
+++ b/specs/issue-168-adw-e85cfm-sdlc_planner-copy-env-local-worktree.md
@@ -1,0 +1,53 @@
+# Chore: Copy .env.local to worktree
+
+## Metadata
+issueNumber: `168`
+adwId: `e85cfm`
+issueJson: `{"title":"copy .env.local to worktree","body":"When creating a new worktree .env is being copied into the worktree. This should also happen for .env.local","state":"OPEN","number":168,"author":"paysdoc"}`
+
+## Chore Description
+When a new git worktree is created by the ADW system, the `copyEnvToWorktree` function in `adws/github/worktreeOperations.ts` copies the `.env` file from the main repository into the new worktree (since `.env` is gitignored and won't be present). However, `.env.local` is also a gitignored environment file that is not being copied. This chore updates `copyEnvToWorktree` to also copy `.env.local` when it exists in the main repository.
+
+## Relevant Files
+Use these files to resolve the chore:
+
+- `adws/github/worktreeOperations.ts` — Contains the `copyEnvToWorktree` function that needs to be updated to also copy `.env.local`.
+- `adws/__tests__/worktreeOperations.test.ts` — Contains the `copyEnvToWorktree` test suite that needs new tests for `.env.local` copying behavior.
+- `adws/__tests__/workflowPhases.test.ts` — References `copyEnvToWorktree` in mocks; may need verification but likely no changes needed since the function signature stays the same.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### Step 1: Update `copyEnvToWorktree` in `adws/github/worktreeOperations.ts`
+- In the `copyEnvToWorktree` function (line 79–94), add logic to also copy `.env.local` from the main repository to the worktree.
+- After the existing `.env` copy block, add a similar block that:
+  1. Constructs `sourceEnvLocalPath` as `path.join(mainRepoPath, '.env.local')`
+  2. Constructs `destEnvLocalPath` as `path.join(worktreePath, '.env.local')`
+  3. Checks if `.env.local` exists in the main repo with `fs.existsSync(sourceEnvLocalPath)`
+  4. If it exists, copies it with `fs.copyFileSync(sourceEnvLocalPath, destEnvLocalPath)` and logs `Copied .env.local file to worktree at ${worktreePath}`
+  5. If it does not exist, logs `No .env.local file found in main repository at ${mainRepoPath}, skipping copy`
+- The error handling `catch` block already wraps the entire function, so the new `.env.local` copy is covered by the existing try-catch.
+- Update the JSDoc comment to mention that both `.env` and `.env.local` are copied.
+
+### Step 2: Add tests for `.env.local` copying in `adws/__tests__/worktreeOperations.test.ts`
+- In the existing `copyEnvToWorktree` describe block (starting at line 1095), add the following test cases:
+  - **`copies .env.local when it exists in main repo`**: Mock `fs.existsSync` to return true for both `.env` and `.env.local`, verify `fs.copyFileSync` is called with `.env.local` source and destination paths.
+  - **`copies .env but not .env.local when only .env exists`**: Mock `fs.existsSync` to return true for `.env` and false for `.env.local`, verify `fs.copyFileSync` is called only once (for `.env`).
+  - **`copies .env.local but not .env when only .env.local exists`**: Mock `fs.existsSync` to return false for `.env` and true for `.env.local`, verify `fs.copyFileSync` is called once (for `.env.local`).
+  - **`copies neither when neither exists`**: Mock `fs.existsSync` to return false for both, verify `fs.copyFileSync` is not called.
+- Update the existing test `copies .env when it exists in main repo` to also account for the `.env.local` existence check (the `fs.existsSync` mock may need to differentiate between `.env` and `.env.local` paths).
+
+### Step 3: Run Validation Commands
+- Run all validation commands listed below to ensure the chore is complete with zero regressions.
+
+## Validation Commands
+Execute every command to validate the chore is complete with zero regressions.
+
+- `npm run lint` - Run linter to check for code quality issues
+- `npm run build` - Build the application to verify no build errors
+- `npm test` - Run tests to validate the chore is complete with zero regressions
+
+## Notes
+- IMPORTANT: strictly adhere to the coding guidelines in `/guidelines`. If necessary, refactor existing code to meet the coding guidelines as part of accomplishing the chore.
+- The function signature of `copyEnvToWorktree` does not change, so callers (`worktreeCreation.ts`, `workflowLifecycle.ts`) require no modifications.
+- The existing `fs.existsSync` mock in test files that mock `copyEnvToWorktree` itself (e.g., `workflowPhases.test.ts`, `tokenLimitRecovery.test.ts`) are unaffected since they mock the entire function, not its internals.


### PR DESCRIPTION
## Summary

When creating a new git worktree, the ADW system copies `.env` from the main repository into the worktree (since `.env` is gitignored). However, `.env.local` was not being copied. This PR updates `copyEnvToWorktree` to also copy `.env.local` when it exists in the main repository.

Closes #168

**Plan file:** `e85cfm`

## What was done

- [x] Updated `copyEnvToWorktree` in `adws/github/worktreeOperations.ts` to also copy `.env.local`
- [x] Added tests for `.env.local` copying behavior (copies both, only `.env`, only `.env.local`, neither)
- [x] Updated JSDoc to reflect that both `.env` and `.env.local` are copied
- [x] Validation: lint, build, and tests pass

## Key changes

- **`adws/github/worktreeOperations.ts`** — Added `.env.local` copy logic after the existing `.env` copy block in `copyEnvToWorktree`
- **`adws/__tests__/worktreeOperations.test.ts`** — Added 4 new test cases covering all combinations of `.env` / `.env.local` existence, updated existing test to differentiate between paths