### PR TITLE
bug: #176 - Fix backticks in branch names causing worktree creation failure

### DIFF
--- a/adws/__tests__/gitAgent.test.ts
+++ b/adws/__tests__/gitAgent.test.ts
@@ -91,6 +91,16 @@ describe('extractBranchNameFromOutput', () => {
     const result = extractBranchNameFromOutput(output);
     expect(result).toBe('feat-issue-123-add-user-auth');
   });
+
+  it('strips backticks from LLM output', () => {
+    const result = extractBranchNameFromOutput('`feat-issue-123-add-user-auth`');
+    expect(result).toBe('feat-issue-123-add-user-auth');
+  });
+
+  it('strips triple backticks from LLM output', () => {
+    const result = extractBranchNameFromOutput('```feat-issue-123-add-user-auth```');
+    expect(result).toBe('feat-issue-123-add-user-auth');
+  });
 });
 
 describe('validateBranchName', () => {
@@ -139,6 +149,11 @@ describe('validateBranchName', () => {
 
   it('throws an error when all characters are invalid', () => {
     expect(() => validateBranchName('~^:*?[]\\')).toThrow('Branch name is empty after validation');
+  });
+
+  it('removes backticks from branch names', () => {
+    expect(validateBranchName('`feat-issue-123-add-auth`')).toBe('feat-issue-123-add-auth');
+    expect(validateBranchName('feat-`issue`-123')).toBe('feat-issue-123');
   });
 });
 

--- a/adws/agents/gitAgent.ts
+++ b/adws/agents/gitAgent.ts
@@ -25,8 +25,8 @@ issue: ${JSON.stringify(issue)}`;
 export function validateBranchName(name: string): string {
   let sanitized = name.trim();
 
-  // Remove characters invalid in git branch names
-  sanitized = sanitized.replace(/[~^:*?[\]@{}\\]/g, '');
+  // Remove characters invalid in git branch names or dangerous in shell contexts
+  sanitized = sanitized.replace(/[~^:*?[\]@{}\\`]/g, '');
   sanitized = sanitized.replace(/\.\./g, '');
   sanitized = sanitized.replace(/\s+/g, '-');
 
@@ -49,7 +49,7 @@ export function validateBranchName(name: string): string {
 export function extractBranchNameFromOutput(output: string): string {
   const trimmed = output.trim();
   const lines = trimmed.split('\n').filter(line => line.trim());
-  const rawName = lines[lines.length - 1].trim();
+  const rawName = lines[lines.length - 1].trim().replace(/^`+|`+$/g, '');
   return validateBranchName(rawName);
 }
 

--- a/adws/github/worktreeOperations.ts
+++ b/adws/github/worktreeOperations.ts
@@ -28,7 +28,7 @@ export interface BranchCheckoutStatus {
  * @returns A safe directory name derived from the branch name
  */
 function sanitizeBranchName(branchName: string): string {
-  return branchName.replace(/[/\\:*?"<>|]/g, '-');
+  return branchName.replace(/[/\\:*?"<>|`]/g, '-');
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes a sporadic worktree creation failure caused by backtick characters (`` ` ``) in generated branch names. When the LLM wraps its branch name output in backticks (Markdown inline code formatting), the shell interprets them as command substitution inside double-quoted `execSync()` calls, causing `git worktree add` to fail with `fatal: '' is not a valid branch name`.

This is the third fix attempt — previous fixes (commits `8b732db` and `a4ca952`) added double-quoting and empty guards but missed the root cause: **double quotes do NOT prevent backtick command substitution in bash/sh**.

## Root Cause

The `validateBranchName()` regex stripped `~^:*?[]@{}\` but omitted the backtick character. Backticks passed through sanitization unchanged and were interpreted as command substitution when interpolated into shell commands.

## Changes

- **`adws/agents/gitAgent.ts`** — Added backtick to `validateBranchName()` invalid character regex; added defense-in-depth stripping of leading/trailing backticks in `extractBranchNameFromOutput()`
- **`adws/github/worktreeOperations.ts`** — Added backtick to `sanitizeBranchName()` regex for directory-name safety
- **`adws/__tests__/gitAgent.test.ts`** — Added 4 test cases covering backtick stripping in both validation and extraction

## Checklist

- [x] Added backtick to `validateBranchName()` sanitization regex
- [x] Added backtick stripping in `extractBranchNameFromOutput()` (defense-in-depth)
- [x] Added backtick to `sanitizeBranchName()` directory sanitization regex
- [x] Added regression tests for backtick handling
- [x] All 626 tests passing
- [x] Lint clean
- [x] Build successful

## Plan

`specs/issue-176-adw-o9x9qe-sdlc_planner-fix-worktree-branch-name-backticks.md`

Closes #176