### PR TITLE
chore: #175 - Update /bug, /chore and /feature

### DIFF
--- a/.claude/commands/bug.md
+++ b/.claude/commands/bug.md
@@ -3,9 +3,9 @@
 Create a new plan to resolve the `Bug` using the exact specified markdown `Plan Format`. Follow the `Instructions` to create the plan use the `Relevant Files` to focus on the right files.
 
 ## Variables
-issueNumber: $1
-adwId: $2
-issueJson: $3
+issueNumber: $1, default 0 if not provided
+adwId: $2, default to `adw-unknown` if not provided
+issueJson: $3, default to empty JSON object if not provided (`{}`)
 
 ## Instructions
 
@@ -103,7 +103,8 @@ Execute every command to validate the bug is fixed with zero regressions.
 ```
 
 ## Bug
-Extract the bug details from the `issueJson` variable (parse the JSON and use the title and body fields).
+If the `issueJson` variable contains a valid JSON object with `title` and `body` fields, extract the bug details from it.
+Otherwise, use the text passed as the argument to this command as the bug description directly.
 
 ## Report
 - Summarize the work you've just done in a concise bullet point list.

--- a/.claude/commands/chore.md
+++ b/.claude/commands/chore.md
@@ -3,9 +3,9 @@
 Create a new plan to resolve the `Chore` using the exact specified markdown `Plan Format`. Follow the `Instructions` to create the plan use the `Relevant Files` to focus on the right files. Follow the `Report` section to properly report the results of your work.
 
 ## Variables
-issueNumber: $1
-adwId: $2
-issueJson: $3
+issueNumber: $1, default 0 if not provided
+adwId: $2, default to `adw-unknown` if not provided
+issueJson: $3, default to empty JSON object if not provided (`{}`)
 
 ## Instructions
 
@@ -79,7 +79,8 @@ Execute every command to validate the chore is complete with zero regressions.
 ```
 
 ## Chore
-Extract the chore details from the `issueJson` variable (parse the JSON and use the title and body fields).
+If the `issueJson` variable contains a valid JSON object with `title` and `body` fields, extract the chore details from it.
+Otherwise, use the text passed as the argument to this command as the chore description directly.
 
 ## Report
 

--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -3,9 +3,9 @@
 Create a new plan to implement the `Feature` using the exact specified markdown `Plan Format`. Follow the `Instructions` to create the plan use the `Relevant Files` to focus on the right files.
 
 ## Variables
-issueNumber: $1
-adwId: $2
-issueJson: $3
+issueNumber: $1, default 0 if not provided
+adwId: $2, default to `adw-unknown` if not provided
+issueJson: $3, default to empty JSON object if not provided (`{}`)
 
 ## Instructions
 
@@ -123,7 +123,8 @@ Execute every command to validate the feature works correctly with zero regressi
 ```
 
 ## Feature
-Extract the feature details from the `issueJson` variable (parse the JSON and use the title and body fields).
+If the `issueJson` variable contains a valid JSON object with `title` and `body` fields, extract the feature details from it.
+Otherwise, use the text passed as the argument to this command as the feature description directly.
 
 ## Report
 

--- a/specs/issue-175-adw-adw-unknown-sdlc_planner-update-slash-commands-defaults.md
+++ b/specs/issue-175-adw-adw-unknown-sdlc_planner-update-slash-commands-defaults.md
@@ -1,0 +1,104 @@
+# Chore: Update /bug, /chore and /feature slash commands to accept defaults
+
+## Metadata
+issueNumber: `175`
+adwId: `adw-unknown`
+issueJson: `{}`
+
+## Chore Description
+The `/bug`, `/chore`, and `/feature` slash commands in `.claude/commands/` currently define three positional variables (`$1` for issueNumber, `$2` for adwId, `$3` for issueJson) with no default values. When these commands are invoked with just a text string (e.g., `/chore 'Update the README'`), the variables `$2` and `$3` are empty, and the extraction logic at the bottom of each file fails because `issueJson` is empty.
+
+The chore is to update all three commands so they:
+1. Accept the existing structured arguments (issueNumber, adwId, issueJson) as before for backward compatibility with the ADW pipeline.
+2. Accept just a text string as a standalone instruction, in which case the variables default to: `issueNumber=0`, `adwId=adw-unknown`, `issueJson={}`.
+3. Use the standalone text directly as the chore/bug/feature description when `issueJson` is not provided.
+
+## Relevant Files
+Use these files to resolve the chore:
+
+- `.claude/commands/bug.md` — The `/bug` slash command template. Needs Variables defaults added and extraction logic updated to handle standalone text.
+- `.claude/commands/chore.md` — The `/chore` slash command template. Same changes as bug.md.
+- `.claude/commands/feature.md` — The `/feature` slash command template. Same changes as bug.md.
+
+## Step by Step Tasks
+IMPORTANT: Execute every step in order, top to bottom.
+
+### Step 1: Update `.claude/commands/bug.md`
+
+- Replace the `## Variables` section with:
+  ```
+  ## Variables
+  issueNumber: $1, default 0 if not provided
+  adwId: $2, default to `adw-unknown` if not provided
+  issueJson: $3, default to empty JSON object if not provided (`{}`)
+  ```
+- Replace the `## Bug` section (at the bottom of the file) from:
+  ```
+  ## Bug
+  Extract the bug details from the `issueJson` variable (parse the JSON and use the title and body fields).
+  ```
+  to:
+  ```
+  ## Bug
+  If the `issueJson` variable contains a valid JSON object with `title` and `body` fields, extract the bug details from it.
+  Otherwise, use the text passed as the argument to this command as the bug description directly.
+  ```
+
+### Step 2: Update `.claude/commands/chore.md`
+
+- Replace the `## Variables` section with:
+  ```
+  ## Variables
+  issueNumber: $1, default 0 if not provided
+  adwId: $2, default to `adw-unknown` if not provided
+  issueJson: $3, default to empty JSON object if not provided (`{}`)
+  ```
+- Replace the `## Chore` section (at the bottom of the file) from:
+  ```
+  ## Chore
+  Extract the chore details from the `issueJson` variable (parse the JSON and use the title and body fields).
+  ```
+  to:
+  ```
+  ## Chore
+  If the `issueJson` variable contains a valid JSON object with `title` and `body` fields, extract the chore details from it.
+  Otherwise, use the text passed as the argument to this command as the chore description directly.
+  ```
+
+### Step 3: Update `.claude/commands/feature.md`
+
+- Replace the `## Variables` section with:
+  ```
+  ## Variables
+  issueNumber: $1, default 0 if not provided
+  adwId: $2, default to `adw-unknown` if not provided
+  issueJson: $3, default to empty JSON object if not provided (`{}`)
+  ```
+- Replace the `## Feature` section (at the bottom of the file) from:
+  ```
+  ## Feature
+  Extract the feature details from the `issueJson` variable (parse the JSON and use the title and body fields).
+  ```
+  to:
+  ```
+  ## Feature
+  If the `issueJson` variable contains a valid JSON object with `title` and `body` fields, extract the feature details from it.
+  Otherwise, use the text passed as the argument to this command as the feature description directly.
+  ```
+
+### Step 4: Run Validation Commands
+
+- Run `npm run lint`, `npm run build`, and `npm test` to validate no regressions.
+
+## Validation Commands
+Execute every command to validate the chore is complete with zero regressions.
+
+- `npm run lint` - Run linter to check for code quality issues
+- `npm run build` - Build the application to verify no build errors
+- `npm test` - Run tests to validate the chore is complete with zero regressions
+
+## Notes
+- IMPORTANT: strictly adhere to the coding guidelines in `/guidelines`. If necessary, refactor existing code to meet the coding guidelines as part of accomplishing the chore.
+- These changes are purely to `.claude/commands/*.md` markdown files (Claude Code slash command templates). They do not affect any TypeScript/JavaScript source code, so there is no risk of build or runtime regressions.
+- The ADW pipeline (`adws/agents/planAgent.ts`) passes a single formatted text argument to these commands via `runClaudeAgentWithCommand`. With the defaults in place, the commands will work identically since `$2` and `$3` resolve to their defaults and the formatted issue text is used directly as the description.
+- The `## Report` section at the bottom of each command file remains unchanged.


### PR DESCRIPTION
## Summary

Updates the `/bug`, `/chore`, and `/feature` slash commands to support both structured arguments (from the ADW pipeline) and standalone text instructions.

- Adds default values for all three positional variables: `issueNumber` defaults to `0`, `adwId` defaults to `adw-unknown`, `issueJson` defaults to `{}`
- Updates the extraction logic in each command to use standalone text as the description when `issueJson` doesn't contain valid JSON with `title` and `body` fields

## Implementation Plan

See [spec](specs/issue-175-adw-adw-unknown-sdlc_planner-update-slash-commands-defaults.md)

## Changes

- `.claude/commands/bug.md` — Added variable defaults and updated Bug section to handle standalone text
- `.claude/commands/chore.md` — Added variable defaults and updated Chore section to handle standalone text
- `.claude/commands/feature.md` — Added variable defaults and updated Feature section to handle standalone text
- `specs/issue-175-adw-adw-unknown-sdlc_planner-update-slash-commands-defaults.md` — Implementation spec

## Checklist

- [x] Updated `/bug` command with defaults and standalone text support
- [x] Updated `/chore` command with defaults and standalone text support
- [x] Updated `/feature` command with defaults and standalone text support
- [x] Added implementation spec

Closes #175