### PR TITLE
feat: #210 - Remove category numbering

### DIFF
--- a/e2e-tests/test_category_names.md
+++ b/e2e-tests/test_category_names.md
@@ -19,8 +19,8 @@ Validate that full category names (e.g., "Royalty", "Statesmen") are displayed i
 ### 2. Home Page — Table of Contents
 1. On the home page, locate the Table of Contents section
 2. Take a screenshot of the table of contents
-3. Verify that the TOC entries display full category names (e.g., "1 Royalty" instead of "1 Category R")
-4. Each TOC entry should show the index followed by the full category name
+3. Verify that the TOC entries display full category names (e.g., "Royalty" instead of "Category R")
+4. Each TOC entry should show the full category name without a numeric prefix
 
 ### 3. Character Detail Page — Category Display
 1. Click on a character link from the home page

--- a/e2e-tests/test_remove_category_numbering.md
+++ b/e2e-tests/test_remove_category_numbering.md
@@ -1,0 +1,28 @@
+# E2E Test: Remove Category Numbering
+
+## Purpose
+Validate that the Table of Contents on the home page no longer shows numeric prefixes before category names (e.g., "Royalty" instead of "1 Royalty").
+
+## Prerequisites
+- Local Supabase is running (`npm run supabase:start`)
+- Supabase database has been reset with migrations and seeds (`npm run supabase:reset`)
+- Application is running locally (`npm run dev`)
+
+## Test Steps
+
+### 1. Home Page — Table of Contents Without Numbering
+1. Navigate to `http://localhost:3000`
+2. Take a screenshot of the Table of Contents
+3. Verify that TOC entries display category names without numeric prefixes (e.g., "Royalty" instead of "1 Royalty")
+4. Verify that no TOC entry text begins with a digit followed by a space
+
+### 2. TOC Link Navigation Still Works
+1. On the home page, click on a TOC link (e.g., "Royalty")
+2. Verify that the page scrolls to the corresponding category section
+3. Verify that the category section heading matches the TOC link text
+
+## Expected Results
+- TOC entries display only the category name without any numeric prefix
+- No TOC entry text matches the pattern `^\d+ .+` (digit followed by space followed by text)
+- Clicking a TOC link scrolls to the correct category section
+- The `<ol>` list structure is preserved in the DOM

--- a/specs/issue-210-adw-remove-category-numb-z1hrbd-sdlc_planner-remove-category-numbering.md
+++ b/specs/issue-210-adw-remove-category-numb-z1hrbd-sdlc_planner-remove-category-numbering.md
@@ -1,0 +1,98 @@
+# Feature: Remove Category Numbering
+
+## Metadata
+issueNumber: `210`
+adwId: `remove-category-numb-z1hrbd`
+issueJson: `{"number":210,"title":"Remove category numbering","body":"Remove the numbering in the list of categories in the overview.","state":"OPEN","author":"paysdoc","labels":[],"createdAt":"2026-02-25T05:58:16Z","comments":[],"actionableComment":null}`
+
+## Feature Description
+Remove the numeric prefixes (1, 2, 3, ...) that currently appear before each category name in the Table of Contents on the overview (home) page. Currently the TableOfContents component renders each entry as `{index + 1} {categoryName}` (e.g., "1 Royalty", "2 Statesmen"). After this change, entries will display only the category name without the leading number.
+
+## User Story
+As a user viewing the characters overview page
+I want to see category names without numbering in the table of contents
+So that the list looks cleaner and is consistent with a Wikipedia-style presentation
+
+## Problem Statement
+The Table of Contents on the overview page displays a numeric prefix before each category name (e.g., "1 Royalty", "2 Statesmen"). This numbering is redundant since the `<ol>` element already implies order, and the explicit numbers add visual clutter. The issue requests removing these numbers for a cleaner appearance.
+
+## Solution Statement
+Remove the `{index + 1}` expression from the `TableOfContents` component's JSX. Since the component already uses an `<ol>` (ordered list) element, native list numbering via CSS can optionally be restored, but since the current CSS sets `list-style: none`, the simplest approach is to just remove the manual number prefix and keep the list unstyled. The `index` parameter in the `.map()` callback can also be removed since it will no longer be used. Update the existing E2E test that validates TOC entries to no longer expect numbered prefixes.
+
+## Relevant Files
+Use these files to implement the feature:
+
+- `src/components/TableOfContents.tsx` — Contains the `{index + 1}` numbering logic on line 17 that needs to be removed.
+- `src/app/globals.css` (lines 210–244) — Contains the `.toc-list` styles including `list-style: none`. No changes needed unless native `<ol>` numbering is desired.
+- `src/app/page.tsx` — Home page that renders `<TableOfContents>`. No changes needed but useful for context.
+- `e2e-tests/test_category_names.md` — E2E test spec that currently expects "1 Royalty" format in the TOC. Needs updating to reflect the new format without numbers.
+- `e2e-tests/characters-overview.spec.ts` — Playwright E2E spec for the overview page. May need verification that no assertions depend on numbered TOC entries.
+- `guidelines/coding_guidelines.md` — Coding guidelines to follow.
+
+### New Files
+- `e2e-tests/test_remove_category_numbering.md` — New E2E test file to validate that category numbering has been removed from the Table of Contents.
+
+## Implementation Plan
+### Phase 1: Foundation
+Review the current `TableOfContents.tsx` component to confirm the exact numbering logic and understand how the `index` variable is used. Confirm that no other component or test depends on the numbered format.
+
+### Phase 2: Core Implementation
+Remove the `{index + 1}` prefix from the JSX in `TableOfContents.tsx`. Remove the unused `index` parameter from the `.map()` callback. This is a single-line change in a single file.
+
+### Phase 3: Integration
+Update the existing E2E test spec `e2e-tests/test_category_names.md` to remove expectations of numbered TOC entries. Create a new E2E test to validate the numbering has been removed. Verify all existing tests and the build still pass.
+
+## Step by Step Tasks
+
+### Step 1: Create E2E test specification
+- Create `e2e-tests/test_remove_category_numbering.md` with steps to validate that the Table of Contents on the home page no longer shows numeric prefixes before category names.
+- The test should:
+  1. Navigate to `http://localhost:3000`
+  2. Take a screenshot of the Table of Contents
+  3. Verify that TOC entries display category names without numeric prefixes (e.g., "Royalty" instead of "1 Royalty")
+  4. Verify that clicking a TOC link still scrolls to the correct category section
+
+### Step 2: Remove numbering from TableOfContents component
+- Edit `src/components/TableOfContents.tsx`
+- On line 14, change `{categories.map((category, index) => (` to `{categories.map((category) => (`
+- On line 17, change `{index + 1} {categoryNames.get(category) ?? category}` to `{categoryNames.get(category) ?? category}`
+
+### Step 3: Update existing E2E test spec for category names
+- Edit `e2e-tests/test_category_names.md`
+- In section "2. Home Page — Table of Contents", update the expected format from `"1 Royalty"` to just `"Royalty"` (remove numbered prefix expectations)
+- Update step 4: remove the expectation that "Each TOC entry should show the index followed by the full category name"
+
+### Step 4: Run validation commands
+- Run `npm run lint` to check for code quality issues
+- Run `npm run build` to verify no build errors
+- Run `npm test` to run tests and validate zero regressions
+
+## Testing Strategy
+### Unit Tests
+- The existing import test in `src/__tests__/app.test.tsx` will verify the `TableOfContents` component still exports correctly.
+- No new unit tests are needed since this is a simple removal of a display element.
+
+### Edge Cases
+- Categories with fallback names (when `categoryNames.get(category)` returns `undefined`, the component falls back to the raw `category` key) — ensure the fallback still works without the number prefix.
+- Empty categories list — the component should still render an empty list without errors.
+- Single category — the list should display one item without a number.
+
+## Acceptance Criteria
+- The Table of Contents on the overview page displays category names without numeric prefixes.
+- TOC links still navigate to the correct category sections.
+- The `<ol>` structure is preserved (no HTML element changes).
+- All existing tests pass without modification (except updated E2E specs).
+- The build completes successfully with no errors.
+- No visual regressions in the rest of the overview page.
+
+## Validation Commands
+Execute every command to validate the feature works correctly with zero regressions.
+
+- `npm run lint` - Run linter to check for code quality issues
+- `npm run build` - Build the application to verify no build errors
+- `npm test` - Run tests to validate the feature works with zero regressions
+
+## Notes
+- IMPORTANT: strictly adhere to the coding guidelines in `/guidelines`. If necessary, refactor existing code to meet the coding guidelines as part of implementing the feature.
+- This is a minimal change — only `TableOfContents.tsx` needs a code change. The CSS (`globals.css`) already has `list-style: none` on `.toc-list`, so removing the manual number won't reveal native `<ol>` numbering.
+- The `<ol>` element is kept rather than changed to `<ul>` to preserve semantic ordering intent, even though numbers are not visually displayed.

--- a/src/components/TableOfContents.tsx
+++ b/src/components/TableOfContents.tsx
@@ -11,10 +11,10 @@ export default function TableOfContents({ categories, categoryNames }: TableOfCo
     <div className="toc">
       <div className="toc-title">Contents</div>
       <ol className="toc-list">
-        {categories.map((category, index) => (
+        {categories.map((category) => (
           <li key={category}>
             <a href={`#category-${category}`}>
-              {index + 1} {categoryNames.get(category) ?? category}
+              {categoryNames.get(category) ?? category}
             </a>
           </li>
         ))}


### PR DESCRIPTION
## Summary

Removes the numeric prefixes from category names in the Table of Contents on the overview (home) page.

Currently, the `TableOfContents` component renders each entry as `{index + 1} {categoryName}` (e.g., "1 Royalty", "2 Statesmen"). This change removes the manual numbering for a cleaner, Wikipedia-style appearance.

## Implementation Plan

See: `specs/issue-210-adw-remove-category-numb-z1hrbd-sdlc_planner-remove-category-numbering.md`

## Changes

- **`src/components/TableOfContents.tsx`** — Removed `{index + 1}` prefix and unused `index` parameter from `.map()` callback
- **`e2e-tests/test_category_names.md`** — Updated existing E2E test spec to no longer expect numbered TOC entries
- **`e2e-tests/test_remove_category_numbering.md`** — New E2E test spec validating that category numbering has been removed

## Checklist

- [x] Remove `{index + 1}` from `TableOfContents.tsx`
- [x] Remove unused `index` parameter from `.map()` callback
- [x] Update existing E2E test spec for category names
- [x] Add new E2E test spec to validate numbering removal

Closes #210

---
ADW: `remove-category-numb-z1hrbd`